### PR TITLE
8 pagination handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Vendor YAML files define how KiwiSSH interacts with each device CLI and how capt
 Each vendor file contains these top-level sections:
 
 - `vendor`: metadata (`id`, `name`, `description`)
-- `session`: session-level output settings (currently `comment_prefix`)
+- `session`: session-level output settings (`comment_prefix`, `prompt`, `pagination`, `include_metadata_in_config`)
 - `commands`: command phases (`pre_backup`, `backup`, `post_backup`)
 - `processing`: optional output cleanup/redaction rules
 
@@ -333,6 +333,9 @@ Each segment is explained in detail below.
 | --- | ----------- | -------- | ------------- |
 | `session.comment_prefix` | If set, command outputs will be prefixed with this string and rendered as comments in the saved config file. This is useful for adding metadata like command descriptions or timestamps directly in the config file. | No | `! ` |
 | `session.prompt` | Optional prompt regex (or list of regexes) used to detect command completion in interactive shells. Match should cover the full prompt line. If omitted or invalid, KiwiSSH falls back to the built-in generic prompt pattern. | No | `[^\r\n=]*[A-Za-z0-9][^\r\n=]*[>#]\s*$` |
+| `session.pagination.enabled` | Enables pagination prompt handling for this vendor. | No | `false` |
+| `session.pagination.patterns` | Pagination regex (or list of regexes) matched against the full last output line. If `session.pagination` is omitted entirely, KiwiSSH falls back to built-in standard pagination detection patterns. | No | Built-in standard pagination pattern list |
+| `session.pagination.response` | Input sent when a pagination prompt is detected (for example a space to continue). | No | Single space character `" "` |
 | `session.include_metadata_in_config` | Controls whether outputs from `metadata: true` commands are prepended as a block in the saved config. Metadata is always present in the backup job log. | No | `false` |
 
 #### commands

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -25,9 +25,10 @@ ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 ## - [user@host ~]#
 ## Notes:
 ## - Excludes '=' to avoid matching config assignment lines
-GENERIC_PROMPT_RE = re.compile(r"[^\r\n=]*[A-Za-z0-9][^\r\n=]*[>#]\s*$")
+GENERIC_PROMPT_PATTERNS = [
+        re.compile(r"[^\r\n=]*[A-Za-z0-9][^\r\n=]*[>#]\s*$"),
+    ]
 
-GENERIC_PROMPT_PATTERNS = [GENERIC_PROMPT_RE]
 
 
 class SSHService:

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -247,8 +247,14 @@ class SSHService:
             ## ..and from random chunk boundaries inside large command outputs
             if patterns:
                 tail = buffer[-4096:]
-                last_line = tail.split("\n")[-1]
-                if self._line_matches_prompt(last_line, patterns):
+                tail_lines = tail.split("\n")
+
+                ### Some devices return a newline right after the command output
+                ## Use the last non-empty line so prompt detection remains reliable
+                while tail_lines and not tail_lines[-1].strip():
+                    tail_lines.pop()
+
+                if tail_lines and self._line_matches_prompt(tail_lines[-1], patterns):
                     ### Collect any trailing bytes that arrive immediately after prompt detection
                     ### This reduces output bleed into the next command on some devices
                     buffer += await self._read_trailing_output(stream)
@@ -269,10 +275,29 @@ class SSHService:
             ### If no pattern matched, read more data with a short timeout to allow for checking the deadline
             remaining = deadline - loop.time()
             if remaining <= 0:
+                ### Check last 1024 bytes for a non-empty line to include in the timeout log
+                timeout_tail = buffer[-1024:]
+                timeout_lines = timeout_tail.split("\n")
+                last_non_empty = ""
+                while timeout_lines:
+                    candidate = timeout_lines.pop().strip("\r")
+                    if candidate.strip():
+                        last_non_empty = candidate
+                        break
+
+                logger.debug(
+                    "Timed out waiting for prompt. Last non-empty output line: %r",
+                    ANSI_ESCAPE_RE.sub("", last_non_empty)[-200:],
+                )
                 raise asyncio.TimeoutError("Timed out waiting for prompt")
 
             ### Read the next chunk of output with a short timeout to allow for prompt detection
-            chunk = await asyncio.wait_for(stream.read(256), timeout=min(remaining, 1.0))
+            try:
+                chunk = await asyncio.wait_for(stream.read(256), timeout=min(remaining, 1.0))
+            except asyncio.TimeoutError:
+                ### No new bytes in this polling window; keep waiting until overall deadline
+                continue
+
             if chunk == "":
                 return buffer
 

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -29,6 +29,14 @@ GENERIC_PROMPT_PATTERNS = [
         re.compile(r"[^\r\n=]*[A-Za-z0-9][^\r\n=]*[>#]\s*$"),
     ]
 
+### Generic pagination patterns to handle common pagination for all vendors as default
+DEFAULT_PAGINATION_PATTERNS = [
+    re.compile(r"^\s*--\s*More\s*--\s*(?:\(\d+%\))?\s*$", re.IGNORECASE),
+    re.compile(r"^\s*---\s*\(more(?: \d+%)?\)\s*---\s*$", re.IGNORECASE),
+    re.compile(r"^\s*More:\s*<space>,\s*Quit:\s*q,\s*One line:\s*<return>\s*$", re.IGNORECASE),
+    re.compile(r"^\s*Press any key to continue(?: or q to quit)?\s*$", re.IGNORECASE),
+    re.compile(r"^\s*Press <space> to continue(?:, q to quit)?\s*$", re.IGNORECASE),
+]
 
 
 class SSHService:
@@ -89,6 +97,62 @@ class SSHService:
             vendor_id,
         )
         return GENERIC_PROMPT_PATTERNS
+
+    def _get_pagination_settings(self, vendor_id: str) -> tuple[list[re.Pattern[str]], str]:
+        """Get optional pager detection patterns and response from vendor session config."""
+        session_config = vendor_service.get_session_parameters(vendor_id)
+        pager_config = session_config.get("pagination")
+
+        ### Default: handle common pager markers even when vendor config doesn't define pager settings
+        if pager_config is None:
+            return list(DEFAULT_PAGINATION_PATTERNS), " "
+
+        if not isinstance(pager_config, dict):
+            logger.warning(
+                "Invalid session.pagination for vendor '%s': expected mapping; disabling pagination handling",
+                vendor_id,
+            )
+            return [], " "
+
+        if not bool(pager_config.get("enabled", False)):
+            return [], " "
+
+        raw_patterns = pager_config.get("patterns", [])
+
+        ### Check for single or multiple pagination patterns and normalize to a list
+        pattern_values: list[str]
+        if isinstance(raw_patterns, str):
+            pattern_values = [raw_patterns]
+        elif isinstance(raw_patterns, list):
+            pattern_values = [str(value) for value in raw_patterns if str(value).strip()]
+        else:
+            logger.warning(
+                "Invalid session.pagination.patterns for vendor '%s': expected string or list; disabling pagination handling",
+                vendor_id,
+            )
+            return [], " "
+
+        ### Validate pagination REGEX patterns
+        compiled_patterns: list[re.Pattern[str]] = []
+        for pattern_value in pattern_values:
+            try:
+                compiled_patterns.append(re.compile(pattern_value))
+            except re.error as ex:
+                logger.warning(
+                    "Invalid session.pagination regex pattern '%s' for vendor '%s': %s",
+                    pattern_value,
+                    vendor_id,
+                    ex,
+                )
+
+        if not compiled_patterns:
+            return [], " "
+
+        response = str(pager_config.get("response", " "))
+        if not response:
+            response = " "
+
+        return compiled_patterns, response
 
     def _get_ssh_options(self, profile_name: str) -> dict[str, Any]:
         """Get SSH options from profile and map known_hosts policy."""
@@ -605,6 +669,7 @@ class SSHService:
         comment_prefix = "! " if not prefix else (prefix if prefix.endswith(" ") else f"{prefix} ")
         include_metadata_in_config = bool(session_config.get("include_metadata_in_config", False))
         prompt_patterns = self._get_prompt_patterns(vendor_id)
+        pagination_patterns, pagination_response = self._get_pagination_settings(vendor_id)
 
         ### Get processing rules for the vendor
         processing_rules = vendor_service.get_processing_rules(vendor_id)

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -99,25 +99,25 @@ class SSHService:
         return GENERIC_PROMPT_PATTERNS
 
     def _get_pagination_settings(self, vendor_id: str) -> tuple[list[re.Pattern[str]], str]:
-        """Get optional pager detection patterns and response from vendor session config."""
+        """Get optional pagination detection patterns and response from vendor session config."""
         session_config = vendor_service.get_session_parameters(vendor_id)
-        pager_config = session_config.get("pagination")
+        pagination_config = session_config.get("pagination")
 
-        ### Default: handle common pager markers even when vendor config doesn't define pager settings
-        if pager_config is None:
+        ### Default: handle common pagination markers even when vendor config doesn't define pagination settings
+        if pagination_config is None:
             return list(DEFAULT_PAGINATION_PATTERNS), " "
 
-        if not isinstance(pager_config, dict):
+        if not isinstance(pagination_config, dict):
             logger.warning(
                 "Invalid session.pagination for vendor '%s': expected mapping; disabling pagination handling",
                 vendor_id,
             )
             return [], " "
 
-        if not bool(pager_config.get("enabled", False)):
+        if not bool(pagination_config.get("enabled", False)):
             return [], " "
 
-        raw_patterns = pager_config.get("patterns", [])
+        raw_patterns = pagination_config.get("patterns", [])
 
         ### Check for single or multiple pagination patterns and normalize to a list
         pattern_values: list[str]
@@ -148,7 +148,7 @@ class SSHService:
         if not compiled_patterns:
             return [], " "
 
-        response = str(pager_config.get("response", " "))
+        response = str(pagination_config.get("response", " "))
         if not response:
             response = " "
 
@@ -229,11 +229,16 @@ class SSHService:
         stream: asyncssh.SSHReader,
         patterns: list[re.Pattern[str]],
         timeout: int,
+        *,
+        stdin: Any | None = None,
+        pagination_patterns: list[re.Pattern[str]] | None = None,
+        pagination_response: str = " ",
     ) -> str:
         """Read stream until one of the patterns appears or timeout is reached."""
         loop = asyncio.get_running_loop()
         deadline = loop.time() + max(1, int(timeout))
         buffer = ""
+        resolved_pagination_patterns = pagination_patterns or []
 
         ### Read in a loop until we see a prompt pattern or hit the timeout
         while True:
@@ -248,6 +253,18 @@ class SSHService:
                     ### This reduces output bleed into the next command on some devices
                     buffer += await self._read_trailing_output(stream)
                     return buffer
+
+                ### Handle pagination prompts (for example '--More--') by sending configured input
+                if tail_lines and resolved_pagination_patterns and self._line_matches_prompt(tail_lines[-1], resolved_pagination_patterns):
+                    if stdin is not None:
+                        stdin.write(pagination_response)
+
+                    ### Remove pagination marker line from captured output to avoid noisy backups
+                    if "\n" in buffer:
+                        buffer = f"{buffer.rsplit('\n', 1)[0]}\n"
+                    else:
+                        buffer = ""
+                    continue
 
             ### If no pattern matched, read more data with a short timeout to allow for checking the deadline
             remaining = deadline - loop.time()
@@ -340,6 +357,8 @@ class SSHService:
         timeout: int,
         wait_for_prompt: bool,
         prompt_patterns: list[re.Pattern[str]],
+        pagination_patterns: list[re.Pattern[str]],
+        pagination_response: str,
     ) -> str:
         """Execute a single command in an interactive shell session."""
         ### Send the command to the shell
@@ -350,7 +369,14 @@ class SSHService:
             return ""
 
         ### Wait until shell responds with a prompt again (shell is ready again)
-        raw = await self._read_until_patterns(process.stdout, prompt_patterns, timeout)
+        raw = await self._read_until_patterns(
+            process.stdout,
+            prompt_patterns,
+            timeout,
+            stdin=process.stdin,
+            pagination_patterns=pagination_patterns,
+            pagination_response=pagination_response,
+        )
 
         ### Return normalized command output
         return self._sanitize_command_output(raw, command, prompt_patterns)
@@ -362,6 +388,8 @@ class SSHService:
         default_timeout: int,
         password: str | None,
         prompt_patterns: list[re.Pattern[str]],
+        pagination_patterns: list[re.Pattern[str]],
+        pagination_response: str,
         capture_output: bool,
         required: bool = True,
     ) -> list[dict[str, Any]]:
@@ -419,6 +447,9 @@ class SSHService:
                             process.stdout,
                             prompt_patterns,
                             default_timeout,
+                            stdin=process.stdin,
+                            pagination_patterns=pagination_patterns,
+                            pagination_response=pagination_response,
                         )
                     else:
                         await asyncio.sleep(0.1)
@@ -445,6 +476,8 @@ class SSHService:
                     timeout=default_timeout,
                     wait_for_prompt=wait_for_prompt,
                     prompt_patterns=prompt_patterns,
+                    pagination_patterns=pagination_patterns,
+                    pagination_response=pagination_response,
                 )
                 if capture_output and output:
                     captured_outputs.append({
@@ -689,6 +722,8 @@ class SSHService:
                 default_timeout=default_timeout,
                 password=password,
                 prompt_patterns=prompt_patterns,
+                pagination_patterns=pagination_patterns,
+                pagination_response=pagination_response,
                 capture_output=False,
             )
 
@@ -698,6 +733,8 @@ class SSHService:
                 default_timeout=default_timeout,
                 password=password,
                 prompt_patterns=prompt_patterns,
+                pagination_patterns=pagination_patterns,
+                pagination_response=pagination_response,
                 capture_output=True,
             )
 
@@ -707,6 +744,8 @@ class SSHService:
                 default_timeout=default_timeout,
                 password=password,
                 prompt_patterns=prompt_patterns,
+                pagination_patterns=pagination_patterns,
+                pagination_response=pagination_response,
                 capture_output=False,
             )
 

--- a/config/vendors/fortinet_fortigate.yaml
+++ b/config/vendors/fortinet_fortigate.yaml
@@ -10,6 +10,11 @@ vendor:
 session:
   comment_prefix: "# "
   prompt: '^(\(\w\) )?([-\w.~]+(\s[(\w\-.)]+)?~?\s?[#>$]\s?)$'
+  pagination:
+    enabled: true
+    patterns:
+      - '^--More--\s*$'
+    response: " "
 
 ### Commands to execute for backup
 ## Supported step types in command phases:

--- a/config/vendors/fortinet_fortios.yaml
+++ b/config/vendors/fortinet_fortios.yaml
@@ -9,6 +9,11 @@ vendor:
 ### Session-level output behavior.
 session:
   comment_prefix: "# "
+  pagination:
+    enabled: true
+    patterns:
+      - '^--More--\s*$'
+    response: " "
 
 ### Commands to execute for backup
 ## Supported step types in command phases:

--- a/frontend/src/components/DiffViewer.vue
+++ b/frontend/src/components/DiffViewer.vue
@@ -268,17 +268,17 @@ function getLineClass(type: string): string {
 
     <!-- Side-by-side diff viewer -->
     <div class="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
-      <div class="grid grid-cols-1 lg:grid-cols-2 divide-y lg:divide-y-0 lg:divide-x divide-slate-200 dark:divide-slate-700 bg-slate-100/90 dark:bg-slate-800/95 border-b border-slate-200 dark:border-slate-700">
+      <div class="grid grid-cols-2 divide-x divide-slate-200 dark:divide-slate-700 bg-slate-100/90 dark:bg-slate-800/95 border-b border-slate-200 dark:border-slate-700">
         <div class="px-4 py-2 font-medium text-slate-700 dark:text-slate-100 text-xs">Original (Removed lines in red)</div>
         <div class="px-4 py-2 font-medium text-slate-700 dark:text-slate-100 text-xs">Modified (Added lines in green)</div>
       </div>
 
       <div class="font-mono text-sm bg-slate-50/50 dark:bg-slate-900 overflow-x-auto">
-        <div class="min-w-max">
+        <div class="min-w-5xl">
           <div
             v-for="(row, rowIndex) in parsedDiff"
             :key="`row-${rowIndex}`"
-            class="grid grid-cols-1 lg:grid-cols-2 divide-y lg:divide-y-0 lg:divide-x divide-slate-200 dark:divide-slate-700"
+            class="grid grid-cols-2 divide-x divide-slate-200 dark:divide-slate-700"
           >
             <!-- Left side line -->
             <div v-if="row.left" :class="getLineClass(row.left.type)" class="flex min-h-7">
@@ -289,7 +289,7 @@ function getLineClass(type: string): string {
                 {{ row.left.lineNum }}
               </div>
               <div v-else class="shrink-0 w-14" />
-              <pre class="flex-1 px-4 py-1 text-gray-800 dark:text-gray-100 whitespace-pre-wrap wrap-break-word"><span
+              <pre class="flex-1 px-4 py-1 text-gray-800 dark:text-gray-100 whitespace-pre-wrap break-all"><span
                 v-for="(segment, segmentIndex) in row.left.segments"
                 :key="`left-${rowIndex}-${segmentIndex}`"
                 :class="segment.changed ? getInlineClass(row.left.type) : ''"
@@ -309,7 +309,7 @@ function getLineClass(type: string): string {
                 {{ row.right.lineNum }}
               </div>
               <div v-else class="shrink-0 w-14" />
-              <pre class="flex-1 px-4 py-1 text-gray-800 dark:text-gray-100 whitespace-pre-wrap wrap-break-word"><span
+              <pre class="flex-1 px-4 py-1 text-gray-800 dark:text-gray-100 whitespace-pre-wrap break-all"><span
                 v-for="(segment, segmentIndex) in row.right.segments"
                 :key="`right-${rowIndex}-${segmentIndex}`"
                 :class="segment.changed ? getInlineClass(row.right.type) : ''"


### PR DESCRIPTION
- Added support for pagination (e.g. '--More--' for Fortinet). This can be set in the vendor YAML files with the keys `session.pagination.enabled=true` and `session.pagination.patterns` + `session.pagination.response`. See the README for more.
- Fixed a bug where the git diff view width would be too large to fit on the screen
- Added auto-enabled pagination support for Fortinet vendor YAML files
- Updated prompt detection logic to work with blank lines