### PR TITLE
Merge dev into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,21 +355,23 @@ Each item in the `commands.<phase>` list follows this structure:
 ```yaml
 commands:
   backups:
-    - command: "show running-config"
+    - command: "show running-config" # simple command
       description: "Get running configuration"
-    - command: "another command here"
-    - type: "send_input"
-      command: "some command that requires input"
-      input: "the input to send after the command"
+    - command: "another command here" # another simple command
+    - command: "enable" # interactive command
+      then: "<enable password>"
+    - command: "logout" # another interactive command
+      then:
+        - "y"
+        - "n"
 ```
 
 You can use the following keys for each command step:
 
 | Key | Description | Required | Default Value |
 | --- | ----------- | -------- | ------------- |
-| `command` | Directly run the command on the device. | **Either `command` or `type`** | - |
-| `type` | Run the command in specified in this item and send the input (`input`) afterwards. If `input` is omitted, the resolved device password will be sent as input. | **Either `command` or `type`** | Must be `send_input` |
-| `input` (for `type: "send_input"` only!) | The input to send after the command. This is only used for `send_input` type steps. If omitted, the resolved device password will be sent as input. If no device password is configured, this must be explicitly set. | No | Resolved device password |
+| `command` | Directly run the command on the device. | **Yes** | - |
+| `then` | Optional interactive input sequence to send after `command`. Must be a YAML list (`then: ["value1", "value2", ...]`) with up to 5 entries. | No | - |
 | `description` | A brief description of the command. | No | - |
 | `metadata` | If set to true, the output of this command will be saved as comment-prefixed metadata block in the backup job log. This is useful for adding important information to the backup job log. | No | `false` |
 | `wait_for_prompt` | If set to false, KiwiSSH will not wait for the command prompt to return after running this command before proceeding to the next step. Use with caution. | No | `true` |

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ commands:
       description: "Get running configuration"
     - command: "another command here" # another simple command
     - command: "enable" # interactive command
-      then: "<enable password>"
+      then: ["<enable password>"]
     - command: "logout" # another interactive command
       then:
         - "y"

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """KiwiSSH Backend - Network Configuration Backup Application."""
 
-__version__ = "1.2.0"
+__version__ = "2.0.0"

--- a/backend/app/api/routes/backups.py
+++ b/backend/app/api/routes/backups.py
@@ -1,11 +1,9 @@
 """Backup operation endpoints."""
 
-import asyncio
 import logging
 from fastapi import APIRouter, HTTPException, Depends, Query
 from sqlalchemy.orm import Session
 
-from app.core import get_settings
 from app.models.backup import BackupTriggerRequest, BackupTriggerResponse
 from app.services.backup_service import backup_service
 from app.services.source_service import source_service
@@ -16,55 +14,6 @@ from app.db.models import BackupJob
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-async def _run_backup_in_background(
-    enabled_devices: list,
-    context_label: str,
-) -> None:
-    """Run backups in background.
-    
-    BackupService.backup_device() handles all job persistence:
-    """
-
-    logger.debug("Background backup started for %s (%d devices)", context_label, len(enabled_devices))
-    max_workers = max(1, int(get_settings().app.threads))
-    queue: asyncio.Queue = asyncio.Queue()
-    for device in enabled_devices:
-        queue.put_nowait(device)
-
-    async def worker() -> None:
-        while True:
-            try:
-                device = await queue.get()
-            except asyncio.CancelledError:
-                return
-
-            try:
-                result = await backup_service.backup_device(device)
-                logger.debug("Backup for %s completed with status: %s", device.device_name, result.status)
-            except Exception as e:
-                logger.error("Unexpected error backing up %s: %s", device.device_name, e)
-            finally:
-                queue.task_done()
-
-    workers = [asyncio.create_task(worker()) for _ in range(max_workers)]
-    try:
-        await queue.join()
-    finally:
-        for task in workers:
-            task.cancel()
-        await asyncio.gather(*workers, return_exceptions=True)
-
-    logger.debug("Background backup completed for %s", context_label)
-
-
-def _log_background_task_result(task: asyncio.Task) -> None:
-    """Log unhandled exceptions from fire-and-forget backup tasks."""
-    try:
-        task.result()
-    except Exception:
-        logger.exception("Background backup task failed")
 
 
 @router.post("/trigger", response_model=BackupTriggerResponse)
@@ -89,14 +38,31 @@ async def trigger_backup(
             job_id=None,
         )
 
-    device_names = [d.device_name for d in enabled_devices]
     context_label = f"group '{request.group}'" if request.group else "all enabled devices"
-    task = asyncio.create_task(_run_backup_in_background(enabled_devices, context_label))
-    task.add_done_callback(_log_background_task_result)
+    queue_source = f"api:group:{request.group}" if request.group else "api:all"
+    queued_devices, skipped_devices = await backup_service.queue_device_backups(
+        enabled_devices,
+        source=queue_source,
+    )
+    queue_depth = backup_service.get_backup_queue_depth()
+
+    if not queued_devices:
+        return BackupTriggerResponse(
+            message=(
+                f"No new backups queued for {context_label}. "
+                f"{len(skipped_devices)} device(s) are already queued or currently running."
+            ),
+            devices_queued=[],
+            job_id=None,
+        )
 
     return BackupTriggerResponse(
-        message=f"Backup job triggered for {context_label}. {len(device_names)} devices queued. Jobs will show 'in_progress' status immediately.",
-        devices_queued=device_names,
+        message=(
+            f"Queued {len(queued_devices)} backup(s) for {context_label}. "
+            f"Skipped {len(skipped_devices)} already queued/running device(s). "
+            f"Current queue depth: {queue_depth}."
+        ),
+        devices_queued=queued_devices,
         job_id=None,
     )
 
@@ -113,11 +79,19 @@ async def trigger_device_backup(
     if device is None:
         raise HTTPException(status_code=404, detail=f"Device '{device_name}' not found")
 
-    task = asyncio.create_task(_run_backup_in_background([device], f"device '{device_name}'"))
-    task.add_done_callback(_log_background_task_result)
+    queued = await backup_service.queue_device_backup(device, source=f"api:device:{device_name}")
+    if not queued:
+        return BackupTriggerResponse(
+            message=f"Backup for device {device_name} is already queued or currently running.",
+            devices_queued=[],
+            job_id=None,
+        )
 
     return BackupTriggerResponse(
-        message=f"Backup job triggered for device {device_name}. Job will show 'in_progress' status immediately.",
+        message=(
+            f"Queued backup for device {device_name}. "
+            f"Current queue depth: {backup_service.get_backup_queue_depth()}."
+        ),
         devices_queued=[device_name],
         job_id=None,
     )

--- a/backend/app/api/routes/backups.py
+++ b/backend/app/api/routes/backups.py
@@ -102,8 +102,9 @@ async def get_backup_jobs(
     device_name: str | None = Query(None, description="Filter by partial device name"),
     job_id: str | None = Query(None, description="Filter by partial job ID"),
     status: str | None = Query(None, description="Filter by status (success, failed, no_changes)"),
-    limit: int = Query(5000, ge=1, le=50000, description="Maximum number of jobs to return"),
+    limit: int = Query(200, ge=1, le=5000, description="Maximum number of jobs to return"),
     offset: int = Query(0, ge=0, description="Number of jobs to skip before returning results"),
+    include_metadata: bool = Query(False, description="Include metadata_output in list response"),
     db: Session = Depends(get_db),
 ) -> dict:
     """Get backup job records from the database."""
@@ -153,7 +154,7 @@ async def get_backup_jobs(
                     "error_message": job.error_message,
                     "config_size_bytes": job.config_size_bytes,
                     "duration_seconds": job.duration_seconds,
-                    "metadata_output": job.metadata_output,
+                    "metadata_output": job.metadata_output if include_metadata else None,
                 }
                 for job in jobs
             ],

--- a/backend/app/fastapi_server.py
+++ b/backend/app/fastapi_server.py
@@ -80,6 +80,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     ### Shutdown
     logger.info("Shutting down KiwiSSH")
     backup_scheduler_service.stop_scheduler()
+    await backup_service.stop_backup_queue()
 
 
 ### Definde FastAPI app

--- a/backend/app/fastapi_server.py
+++ b/backend/app/fastapi_server.py
@@ -13,6 +13,7 @@ from app.api.routes import api_router_v1
 from app.core import get_settings
 from app.core.logging import configure_logging
 from app.services import source_service
+from app.services.backup_service import backup_service
 from app.services.backup_scheduler_service import backup_scheduler_service
 from app.services.backup_job_service import backup_job_service
 from app.db import database
@@ -67,6 +68,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 db.close()
         except Exception as e:
             logger.warning(f"Failed to clean up stuck jobs during startup: {e}")
+
+    ### Start global backup queue workers
+    await backup_service.start_backup_queue()
     
     ### Start backup scheduler
     backup_scheduler_service.start_scheduler(devices)

--- a/backend/app/services/backup_job_service.py
+++ b/backend/app/services/backup_job_service.py
@@ -177,41 +177,6 @@ class BackupJobService:
 
         return latest_jobs
 
-    @staticmethod
-    def get_device_jobs(db: Session, device_name: str, limit: int = 10) -> list[BackupJob]:
-        """Get backup job history for a device.
-
-        Args:
-            db: Database session
-            device_name: Name of the device
-            limit: Maximum number of records to return
-
-        Returns:
-            List of BackupJob records
-        """
-        return db.query(BackupJob).filter(
-            BackupJob.device_name == device_name
-        ).order_by(
-            desc(BackupJob.timestamp)
-        ).limit(limit).all()
-
-    @staticmethod
-    def get_failed_jobs(db: Session, limit: int = 50) -> list[BackupJob]:
-        """Get recent failed backup jobs.
-
-        Args:
-            db: Database session
-            limit: Maximum number of records to return
-
-        Returns:
-            List of failed BackupJob records
-        """
-        return db.query(BackupJob).filter(
-            BackupJob.status == "failed"
-        ).order_by(
-            desc(BackupJob.timestamp)
-        ).limit(limit).all()
-
 
 ### Singleton instance
 backup_job_service = BackupJobService()

--- a/backend/app/services/backup_job_service.py
+++ b/backend/app/services/backup_job_service.py
@@ -135,6 +135,18 @@ class BackupJobService:
             desc(BackupJob.timestamp)
         ).first()
 
+    ### Helper method for config size validation
+    @staticmethod
+    def get_latest_completed_job(db: Session, device_name: str) -> BackupJob | None:
+        """Get the most recent completed backup job with known config size for a device."""
+        return db.query(BackupJob).filter(
+            BackupJob.device_name == device_name,
+            BackupJob.status.in_(["success", "no_changes"]),
+            BackupJob.config_size_bytes.isnot(None),
+        ).order_by(
+            desc(BackupJob.timestamp)
+        ).first()
+
     @staticmethod
     def get_latest_jobs_for_devices(db: Session, device_names: list[str]) -> dict[str, BackupJob]:
         """Get the most recent backup job for multiple devices in a single query.

--- a/backend/app/services/backup_scheduler_service.py
+++ b/backend/app/services/backup_scheduler_service.py
@@ -90,12 +90,21 @@ class BackupSchedulerService:
         
         This is called by the scheduler at the configured cron time.
         """
-        logger.debug(f"Scheduled backup triggered for device: {device.device_name}")
+        logger.debug("Scheduled backup triggered for device: %s", device.device_name)
         
         try:
             ### Call the backup service
-            await backup_service.backup_device(device)
-            logger.debug(f"Scheduled backup completed for device: {device.device_name}")
+            queued = await backup_service.queue_device_backup(
+                device,
+                source=f"scheduler:{device.device_name}",
+            )
+            if queued:
+                logger.debug("Scheduled backup queued for device: %s", device.device_name)
+            else:
+                logger.debug(
+                    "Scheduled backup skipped for %s (already queued or running)",
+                    device.device_name,
+                )
         except Exception as ex:
             logger.error(f"Scheduled backup failed for device {device.device_name}: {ex}")
 

--- a/backend/app/services/backup_scheduler_service.py
+++ b/backend/app/services/backup_scheduler_service.py
@@ -51,39 +51,13 @@ class BackupSchedulerService:
             timezone=timezone,
         )
 
-    def get_device_schedule(self, device: DeviceBase) -> ScheduleConfig | None:
+    def _get_device_schedule(self, device: DeviceBase) -> ScheduleConfig | None:
         """Resolve device schedule with priority: app < group < node.
         
         Returns the resolved ScheduleConfig for the device, or None if no schedule is configured.
         """
         device_config = self.settings.get_device_config(device.group, device.device_name)
         return device_config.get("schedule")
-
-    def is_device_scheduled(self, device: DeviceBase) -> bool:
-        """Check if a device has a backup schedule configured.
-        
-        Args:
-            device: Device to check
-            
-        Returns:
-            True if the device has a schedule with a cron expression, False otherwise
-        """
-        if not device.enabled:
-            return False
-
-        schedule = self.get_device_schedule(device)
-        return schedule is not None and schedule.cron is not None
-
-    def get_all_scheduled_devices(self, devices: list[DeviceBase]) -> list[DeviceBase]:
-        """Get all devices that have backup scheduling enabled.
-        
-        Args:
-            devices: List of all devices
-            
-        Returns:
-            List of devices with scheduling enabled
-        """
-        return [device for device in devices if self.is_device_scheduled(device)]
 
     async def _trigger_device_backup(self, device: DeviceBase) -> None:
         """Trigger a backup for a device.
@@ -137,7 +111,7 @@ class BackupSchedulerService:
                     )
                     continue
 
-                schedule = self.get_device_schedule(device)
+                schedule = self._get_device_schedule(device)
                 if schedule and schedule.cron:
                     try:
                         ### Create timezone object

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -300,7 +300,7 @@ class BackupService:
             job_id: ID of job to update
             result: BackupRecord with final backup result
         """
-        try:            
+        try:
             if database.SessionLocal is None or job_id is None:
                 return
             
@@ -371,6 +371,7 @@ class BackupService:
                 group=device.group,
             )
 
+            config_size = len(config.encode("utf-8"))
             duration_seconds = max(0.0, time.perf_counter() - started_at)
 
             ### If no changes detected, return NO_CHANGES status

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -39,6 +39,10 @@ class BackupService:
         self._backup_queue: asyncio.Queue[QueuedBackupItem] | None = None # items leave this queue when a worker starts processing
         self._queue_workers: list[asyncio.Task[None]] = []
         self._queue_worker_limit: int | None = None
+        self._queue_state_lock: asyncio.Lock | None = None
+        self._queue_setup_lock: asyncio.Lock | None = None
+        ### Dedupe set for device names that are either waiting in queue or currently running
+        self._queued_or_running: set[str] = set()
 
     def _get_ssh_fetch_semaphore(self) -> asyncio.Semaphore:
         """Get semaphore that limits concurrent SSH fetch sessions globally."""
@@ -51,6 +55,17 @@ class BackupService:
 
         return self._ssh_fetch_semaphore
 
+    def _get_queue_state_lock(self) -> asyncio.Lock:
+        """Get lock guarding queued/running device queue."""
+        if self._queue_state_lock is None:
+            self._queue_state_lock = asyncio.Lock()
+        return self._queue_state_lock
+
+    def _get_queue_setup_lock(self) -> asyncio.Lock:
+        """Get lock guarding queue worker startup/shutdown transitions."""
+        if self._queue_setup_lock is None:
+            self._queue_setup_lock = asyncio.Lock()
+        return self._queue_setup_lock
     def _map_status_to_job_status(self, status: BackupStatus) -> str:
         """Map backup result status to persisted job status string.
         

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -97,6 +97,10 @@ class BackupService:
             ]
 
             logger.info("Started global backup queue with %d worker(s)", configured_workers)
+
+    async def start_backup_queue(self) -> None:
+        """Start backup queue workers proactively (used during app startup)."""
+        await self._ensure_backup_queue_workers()
     def _map_status_to_job_status(self, status: BackupStatus) -> str:
         """Map backup result status to persisted job status string.
         

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -165,6 +165,50 @@ class BackupService:
         setup_lock = self._get_queue_setup_lock()
         async with setup_lock:
             await self._stop_backup_queue_locked()
+    async def _queue_device_backup(self, device: DeviceBase, *, source: str) -> bool:
+        """Queue a single device backup assuming queue workers are already initialized."""
+        ### No backup if device is disabled
+        if not device.enabled:
+            return False
+
+        if self._backup_queue is None:
+            raise RuntimeError("Backup queue is not initialized")
+
+        ### Lock protects dedupe checks and updates against concurrent API/scheduler enqueue calls
+        state_lock = self._get_queue_state_lock()
+        async with state_lock:
+            if device.device_name in self._queued_or_running:
+                logger.debug(
+                    "Skipped queue for %s from %s: already queued or running",
+                    device.device_name,
+                    source,
+                )
+                return False
+
+            ### Reserve device name before enqueue so concurrent callers can't queue duplicates
+            self._queued_or_running.add(device.device_name)
+
+        try:
+            ### Put now contains all context workers need (device + source + enqueue timestamp)
+            await self._backup_queue.put(
+                QueuedBackupItem(
+                    device=device,
+                    source=source,
+                    enqueued_at=time.perf_counter(),
+                )
+            )
+        except Exception:
+            async with state_lock:
+                self._queued_or_running.discard(device.device_name)
+            raise
+
+        logger.debug(
+            "Queued backup for %s from %s (queue depth: %d)",
+            device.device_name,
+            source,
+            self.get_backup_queue_depth(),
+        )
+        return True
     def _map_status_to_job_status(self, status: BackupStatus) -> str:
         """Map backup result status to persisted job status string.
         

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -347,7 +347,7 @@ class BackupService:
             BackupRecord with backup status and job_id for tracking
         """
         ### Create in_progress job so UI can show backup status immediately
-        job_id = self._create_in_progress_job(device)
+        job_id = await asyncio.to_thread(self._create_in_progress_job, device)
         started_at = time.perf_counter()
         metadata_output: str | None = None
         
@@ -392,7 +392,7 @@ class BackupService:
                     duration_seconds=duration_seconds,
                     metadata_output=metadata_output,
                 )
-                self._update_job_final_status(job_id, result)
+                await asyncio.to_thread(self._update_job_final_status, job_id, result)
                 return result
 
             logger.info(
@@ -412,7 +412,7 @@ class BackupService:
                 duration_seconds=duration_seconds,
                 metadata_output=metadata_output,
             )
-            self._update_job_final_status(job_id, result)
+            await asyncio.to_thread(self._update_job_final_status, job_id, result)
             return result
 
         except Exception as e:
@@ -427,7 +427,7 @@ class BackupService:
                 duration_seconds=max(0.0, time.perf_counter() - started_at),
                 metadata_output=metadata_output,
             )
-            self._update_job_final_status(job_id, result)
+            await asyncio.to_thread(self._update_job_final_status, job_id, result)
             return result
 
     async def get_backup_status(self, job_id: str) -> dict:

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -34,8 +34,6 @@ class BackupService:
     """Service for orchestrating device backups."""
 
     def __init__(self) -> None:
-        self._ssh_fetch_semaphore: asyncio.Semaphore | None = None
-        self._ssh_fetch_limit: int | None = None
         self._backup_queue: asyncio.Queue[QueuedBackupItem] | None = None # items leave this queue when a worker starts processing
         self._queue_workers: list[asyncio.Task[None]] = []
         self._queue_worker_limit: int | None = None
@@ -43,17 +41,6 @@ class BackupService:
         self._queue_setup_lock: asyncio.Lock | None = None
         ### Dedupe set for device names that are either waiting in queue or currently running
         self._queued_or_running: set[str] = set()
-
-    def _get_ssh_fetch_semaphore(self) -> asyncio.Semaphore:
-        """Get semaphore that limits concurrent SSH fetch sessions globally."""
-        configured_limit = max(1, int(get_settings().app.threads))
-
-        if self._ssh_fetch_semaphore is None or self._ssh_fetch_limit != configured_limit:
-            self._ssh_fetch_semaphore = asyncio.Semaphore(configured_limit)
-            self._ssh_fetch_limit = configured_limit
-            logger.debug("Configured concurrent SSH fetch limit: %d", configured_limit)
-
-        return self._ssh_fetch_semaphore
 
     def _get_queue_state_lock(self) -> asyncio.Lock:
         """Get lock guarding queued/running device queue."""
@@ -201,11 +188,9 @@ class BackupService:
         try:
             logger.info(f"Backing up device: {device.device_name} (group: {device.group})")
             ### Get config from device via SSH (or simulator)
-            ssh_fetch_semaphore = self._get_ssh_fetch_semaphore()
-            async with ssh_fetch_semaphore:
-                ### SSHService resolves merged auth settings..
-                ## ..internally via settings.get_device_config.
-                config, metadata_output = await ssh_service.get_config(device)
+            ### SSHService resolves merged auth settings..
+            ## ..internally via settings.get_device_config.
+            config, metadata_output = await ssh_service.get_config(device)
             logger.debug(f"Got config for {device.device_name} ({len(config)} bytes)")
 
             ### Save config to git (using device's group)

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import time
 import uuid
+from dataclasses import dataclass
 
 from app.core import get_settings
 from app.models.backup import BackupRecord, BackupStatus
@@ -21,12 +22,23 @@ from app.utils.timezone import get_utc_now
 logger = logging.getLogger(__name__)
 
 
+@dataclass(slots=True)
+class QueuedBackupItem:
+    """Queue entry with enqueue metadata for diagnostics."""
+    device: DeviceBase
+    source: str # origin marker (e.g. api:group:<name>, api:device:<name>, scheduler:<name>)
+    enqueued_at: float # timestamp to calculate queue wait time in workers
+
+
 class BackupService:
     """Service for orchestrating device backups."""
 
     def __init__(self) -> None:
         self._ssh_fetch_semaphore: asyncio.Semaphore | None = None
         self._ssh_fetch_limit: int | None = None
+        self._backup_queue: asyncio.Queue[QueuedBackupItem] | None = None # items leave this queue when a worker starts processing
+        self._queue_workers: list[asyncio.Task[None]] = []
+        self._queue_worker_limit: int | None = None
 
     def _get_ssh_fetch_semaphore(self) -> asyncio.Semaphore:
         """Get semaphore that limits concurrent SSH fetch sessions globally."""

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -165,6 +165,14 @@ class BackupService:
         setup_lock = self._get_queue_setup_lock()
         async with setup_lock:
             await self._stop_backup_queue_locked()
+
+    def get_backup_queue_depth(self) -> int:
+        """Return number of queued devices waiting for a worker."""
+        ### Depth includes only waiting items in queue, not currently running backups
+        if self._backup_queue is None:
+            return 0
+        return self._backup_queue.qsize()
+
     async def _queue_device_backup(self, device: DeviceBase, *, source: str) -> bool:
         """Queue a single device backup assuming queue workers are already initialized."""
         ### No backup if device is disabled

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -140,21 +140,26 @@ class BackupService:
             active_workers = [worker for worker in self._queue_workers if not worker.done()]
             self._queue_workers = active_workers
 
-            ## -> If active workers match configured count, we're good. If not, restart workers to match new count
-            if active_workers and self._queue_worker_limit == configured_workers:
+            ## -> If we have enough active workers, just update the limit and return
+            active_count = len(active_workers)
+            if active_count >= configured_workers:
+                self._queue_worker_limit = active_count
                 return
 
-            ## -> If we have active workers but the concurrency config changed, stop all workers and start new ones with updated concurrency
-            if active_workers:
-                await self._stop_backup_queue_locked()
-
+            ## -> Create new workers to meet the configured count
+            missing_workers = configured_workers - active_count
+            start_index = active_count
+            self._queue_workers.extend(
+                asyncio.create_task(self._backup_queue_worker(start_index + index + 1))
+                for index in range(missing_workers)
+            )
             self._queue_worker_limit = configured_workers
-            self._queue_workers = [
-                asyncio.create_task(self._backup_queue_worker(index + 1))
-                for index in range(configured_workers)
-            ]
 
-            logger.info("Started global backup queue with %d worker(s)", configured_workers)
+            logger.info(
+                "Ensured global backup queue workers: %d active (target: %d)",
+                len(self._queue_workers),
+                configured_workers,
+            )
 
     async def start_backup_queue(self) -> None:
         """Start backup queue workers proactively (used during app startup)."""

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -66,6 +66,37 @@ class BackupService:
         if self._queue_setup_lock is None:
             self._queue_setup_lock = asyncio.Lock()
         return self._queue_setup_lock
+    async def _ensure_backup_queue_workers(self) -> None:
+        """Ensure queue workers are running with current configured concurrency."""
+        setup_lock = self._get_queue_setup_lock()
+        async with setup_lock:
+            ### Worker count limit is set via app.threads
+            configured_workers = max(1, int(get_settings().app.threads))
+
+            ### Init queue if not already done
+            if self._backup_queue is None:
+                self._backup_queue = asyncio.Queue()
+
+            ### Worker Lifecycle Management
+            ## -> Remove any workers that have died unexpectedly (Arbeitsunfall § 8 SGB VII)
+            active_workers = [worker for worker in self._queue_workers if not worker.done()]
+            self._queue_workers = active_workers
+
+            ## -> If active workers match configured count, we're good. If not, restart workers to match new count
+            if active_workers and self._queue_worker_limit == configured_workers:
+                return
+
+            ## -> If we have active workers but the concurrency config changed, stop all workers and start new ones with updated concurrency
+            if active_workers:
+                await self._stop_backup_queue_locked()
+
+            self._queue_worker_limit = configured_workers
+            self._queue_workers = [
+                asyncio.create_task(self._backup_queue_worker(index + 1)) # WIP
+                for index in range(configured_workers)
+            ]
+
+            logger.info("Started global backup queue with %d worker(s)", configured_workers)
     def _map_status_to_job_status(self, status: BackupStatus) -> str:
         """Map backup result status to persisted job status string.
         

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -6,6 +6,7 @@ to backup device configurations.
 
 import asyncio
 import logging
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -28,6 +29,14 @@ class QueuedBackupItem:
     device: DeviceBase
     source: str # origin marker (e.g. api:group:<name>, api:device:<name>, scheduler:<name>)
     enqueued_at: float # timestamp to calculate queue wait time in workers
+
+### REGEX Patterns used in config validation 
+CLI_ERROR_PATTERNS = [
+    re.compile(r"^%\s*(?:Unrecognized command|Invalid input detected|Unknown command|Incomplete command)", re.IGNORECASE),
+    re.compile(r"Invalid input detected at '\^' marker", re.IGNORECASE),
+    re.compile(r"^\s*\^\s*$"),
+    re.compile(r"^\s*syntax error\b", re.IGNORECASE),
+]
 
 
 class BackupService:
@@ -327,6 +336,69 @@ class BackupService:
         except Exception as e:
             logger.warning("Failed to update job %s: %s", job_id, e)
 
+    ###### ========================================
+    ### Validate Config Section
+    @staticmethod
+    def _find_cli_error_signature(config: str) -> str | None:
+        """Return first matching CLI-error line if captured config looks invalid."""
+        normalized = config.replace("\r\n", "\n").replace("\r", "\n")
+        for line in normalized.split("\n"):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            for pattern in CLI_ERROR_PATTERNS:
+                if pattern.search(stripped):
+                    return stripped
+        return None
+
+    @staticmethod
+    def _count_non_empty_lines(config: str) -> int:
+        """Count non-empty lines for quick config sanity checks."""
+        return sum(1 for line in config.replace("\r\n", "\n").replace("\r", "\n").split("\n") if line.strip())
+
+    def _get_latest_completed_config_size(self, device_name: str) -> int | None:
+        """Get previous successful/no-change config size for this device."""
+        try:
+            if database.SessionLocal is None:
+                return None
+
+            db = database.SessionLocal()
+            try:
+                previous_job = backup_job_service.get_latest_completed_job(db, device_name)
+                if previous_job is None or previous_job.config_size_bytes is None:
+                    return None
+                return int(previous_job.config_size_bytes)
+            finally:
+                db.close()
+        except Exception as ex:
+            logger.debug("Could not fetch previous config size for %s: %s", device_name, ex)
+            return None
+
+    def _validate_config_capture(self, device_name: str, config: str) -> int:
+        """Validate captured config quality before persisting it to git."""
+        config_size = len(config.encode("utf-8"))
+        non_empty_lines = self._count_non_empty_lines(config)
+
+        ### Raise error if CLI error patterns are detected
+        error_signature = self._find_cli_error_signature(config)
+        if error_signature:
+            raise RuntimeError(
+                f"Captured config appears invalid (CLI error detected): {error_signature}"
+            )
+
+        ### Raise error if config is suspiciously small compared to previous successful backup
+        previous_size = self._get_latest_completed_config_size(device_name)
+        if previous_size is not None and previous_size >= 8192: # Size in bytes
+            minimum_expected_size = max(1024, int(previous_size * 0.20)) # equals to at least 20% of previous size or 1KB, whichever is larger
+            if config_size < minimum_expected_size and non_empty_lines < 60:
+                raise RuntimeError(
+                    "Captured config is suspiciously small compared to previous successful backup "
+                    f"({config_size} bytes vs previous {previous_size} bytes)"
+                )
+
+        return config_size
+    ###### ========================================
+
     async def backup_device(
         self,
         device: DeviceBase,
@@ -369,6 +441,9 @@ class BackupService:
             config, metadata_output = await ssh_service.get_config(device)
             logger.debug(f"Got config for {device.device_name} ({len(config)} bytes)")
 
+            ### Validate config for obvious capture issues before saving to git
+            config_size = await asyncio.to_thread(self._validate_config_capture, device.device_name, config)
+
             ### Save config to git (using device's group)
             commit_hash, has_changes = await git_service.save_config(
                 device.device_name,
@@ -376,7 +451,6 @@ class BackupService:
                 group=device.group,
             )
 
-            config_size = len(config.encode("utf-8"))
             duration_seconds = max(0.0, time.perf_counter() - started_at)
 
             ### If no changes detected, return NO_CHANGES status

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -53,6 +53,35 @@ class BackupService:
         if self._queue_setup_lock is None:
             self._queue_setup_lock = asyncio.Lock()
         return self._queue_setup_lock
+    async def _stop_backup_queue_locked(self) -> None:
+        """Stop queue workers; caller must hold setup lock."""
+        if not self._queue_workers:
+            return
+
+        ### Schick die Arbeiter in den Feierabend
+        for worker in self._queue_workers:
+            worker.cancel()
+        await asyncio.gather(*self._queue_workers, return_exceptions=True)
+
+        self._queue_workers = []
+        self._queue_worker_limit = None
+
+        ### Discard any queued backups 
+        if self._backup_queue is not None:
+            while not self._backup_queue.empty():
+                try:
+                    self._backup_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                else:
+                    self._backup_queue.task_done()
+
+        state_lock = self._get_queue_state_lock()
+        async with state_lock:
+            self._queued_or_running.clear()
+
+        logger.info("Stopped global backup queue workers")
+
     async def _ensure_backup_queue_workers(self) -> None:
         """Ensure queue workers are running with current configured concurrency."""
         setup_lock = self._get_queue_setup_lock()
@@ -88,6 +117,12 @@ class BackupService:
     async def start_backup_queue(self) -> None:
         """Start backup queue workers proactively (used during app startup)."""
         await self._ensure_backup_queue_workers()
+
+    async def stop_backup_queue(self) -> None:
+        """Stop backup queue workers gracefully (used during app shutdown)."""
+        setup_lock = self._get_queue_setup_lock()
+        async with setup_lock:
+            await self._stop_backup_queue_locked()
     def _map_status_to_job_status(self, status: BackupStatus) -> str:
         """Map backup result status to persisted job status string.
         

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -209,6 +209,32 @@ class BackupService:
             self.get_backup_queue_depth(),
         )
         return True
+
+    async def queue_device_backup(self, device: DeviceBase, *, source: str) -> bool:
+        """Queue a single device backup if not already queued/running."""
+        await self._ensure_backup_queue_workers()
+        return await self._queue_device_backup(device, source=source)
+
+    async def queue_device_backups(self, devices: list[DeviceBase], *, source: str) -> tuple[list[str], list[str]]:
+        """Queue multiple device backups and return queued/skipped device names."""
+        await self._ensure_backup_queue_workers()
+
+        queued: list[str] = []
+        skipped: list[str] = []
+
+        ### Queue each device independently so one enqueue failure doesn't abort the whole batch
+        for device in devices:
+            try:
+                if await self._queue_device_backup(device, source=source):
+                    queued.append(device.device_name)
+                else:
+                    skipped.append(device.device_name)
+            except Exception as ex:
+                skipped.append(device.device_name)
+                logger.error("Failed to queue backup for %s from %s: %s", device.device_name, source, ex)
+
+        return queued, skipped
+
     def _map_status_to_job_status(self, status: BackupStatus) -> str:
         """Map backup result status to persisted job status string.
         

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -53,6 +53,48 @@ class BackupService:
         if self._queue_setup_lock is None:
             self._queue_setup_lock = asyncio.Lock()
         return self._queue_setup_lock
+
+    async def _backup_queue_worker(self, worker_id: int) -> None:
+        """Consume queued devices and execute backups with set worker concurrency."""
+        if self._backup_queue is None:
+            return
+
+        while True:
+            try:
+                ### Blocks until a queued device is available or the worker is cancelled
+                queued_item = await self._backup_queue.get()
+            except asyncio.CancelledError:
+                return
+
+            try:
+                ### Queue wait is how long the item sat in FIFO queue before a worker picked it up
+                queue_wait_seconds = max(0.0, time.perf_counter() - queued_item.enqueued_at)
+                result = await self.backup_device(
+                    queued_item.device,
+                    queue_wait_seconds=queue_wait_seconds,
+                    queue_source=queued_item.source,
+                )
+                logger.debug(
+                    "Queue worker %d completed backup for %s with status %s (queue wait %.2fs)",
+                    worker_id,
+                    queued_item.device.device_name,
+                    result.status,
+                    queue_wait_seconds,
+                )
+            except Exception as ex:
+                logger.error(
+                    "Queue worker %d failed backup for %s: %s",
+                    worker_id,
+                    queued_item.device.device_name,
+                    ex,
+                )
+            finally:
+                ### Always release dedupe state and notify queue completion, even on failure.
+                state_lock = self._get_queue_state_lock()
+                async with state_lock:
+                    self._queued_or_running.discard(queued_item.device.device_name)
+                self._backup_queue.task_done()
+
     async def _stop_backup_queue_locked(self) -> None:
         """Stop queue workers; caller must hold setup lock."""
         if not self._queue_workers:
@@ -108,7 +150,7 @@ class BackupService:
 
             self._queue_worker_limit = configured_workers
             self._queue_workers = [
-                asyncio.create_task(self._backup_queue_worker(index + 1)) # WIP
+                asyncio.create_task(self._backup_queue_worker(index + 1))
                 for index in range(configured_workers)
             ]
 
@@ -202,7 +244,13 @@ class BackupService:
         except Exception as e:
             logger.warning("Failed to update job %s: %s", job_id, e)
 
-    async def backup_device(self, device: DeviceBase) -> BackupRecord:
+    async def backup_device(
+        self,
+        device: DeviceBase,
+        *,
+        queue_wait_seconds: float | None = None,
+        queue_source: str | None = None,
+    ) -> BackupRecord:
         """
         Perform backup for a single device.
         
@@ -221,7 +269,17 @@ class BackupService:
         metadata_output: str | None = None
         
         try:
-            logger.info(f"Backing up device: {device.device_name} (group: {device.group})")
+            if queue_wait_seconds is None:
+                logger.info("Backing up device: %s (group: %s)", device.device_name, device.group)
+            else:
+                logger.info(
+                    "Backing up device: %s (group: %s, queue source: %s, queue wait: %.2fs)",
+                    device.device_name,
+                    device.group,
+                    queue_source or "unknown",
+                    queue_wait_seconds,
+                )
+
             ### Get config from device via SSH (or simulator)
             ### SSHService resolves merged auth settings..
             ## ..internally via settings.get_device_config.
@@ -235,7 +293,6 @@ class BackupService:
                 group=device.group,
             )
 
-            config_size = len(config.encode("utf-8"))
             duration_seconds = max(0.0, time.perf_counter() - started_at)
 
             ### If no changes detected, return NO_CHANGES status

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -4,7 +4,9 @@ This service handles Git-based configuration storage, including
 commits, history retrieval, and diff generation.
 """
 
+import asyncio
 import logging
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -27,6 +29,17 @@ class GitService:
     def __init__(self) -> None:
         self.settings = get_settings()
         self._repos: dict[str, Any] = {}  # Cache repos by group
+        self._repo_locks: dict[str, threading.RLock] = {}
+        self._repo_locks_guard = threading.Lock()
+
+    def _get_repo_lock(self, group: str) -> threading.RLock:
+        """Get per-group lock guarding GitPython repository access."""
+        with self._repo_locks_guard:
+            lock = self._repo_locks.get(group)
+            if lock is None:
+                lock = threading.RLock()
+                self._repo_locks[group] = lock
+            return lock
 
     @property
     def backups_base_dir(self) -> Path:
@@ -181,7 +194,7 @@ class GitService:
         self._repos[group] = repo
         return repo
 
-    async def save_config(
+    def _save_config_sync(
         self,
         device_name: str,
         config_content: str,
@@ -201,50 +214,68 @@ class GitService:
             Tuple of (git commit hash, has_changes)
             - has_changes=False means the config is identical to the last backup
         """
-        repo = self._ensure_repo(group)
-        repo_path = self._get_repo_path(group)
+        lock = self._get_repo_lock(group)
+        with lock:
+            repo = self._ensure_repo(group)
+            repo_path = self._get_repo_path(group)
 
-        ### Determine file path based on device info
-        config_file = repo_path / f"{device_name}.conf"
+            ### Determine file path based on device info
+            config_file = repo_path / f"{device_name}.conf"
 
-        ### Check if file exists and has identical content (no changes)
-        has_changes = True
-        if config_file.exists():
-            with open(config_file, "r", encoding="utf-8") as f:
-                existing_content = f.read()
-            if existing_content == config_content:
-                has_changes = False
+            ### Check if file exists and has identical content (no changes)
+            has_changes = True
+            if config_file.exists():
+                with open(config_file, "r", encoding="utf-8") as f:
+                    existing_content = f.read()
+                if existing_content == config_content:
+                    has_changes = False
 
-        ### Write config to file
-        with open(config_file, "w", encoding="utf-8") as f:
-            f.write(config_content)
+            ### Write config to file
+            with open(config_file, "w", encoding="utf-8") as f:
+                f.write(config_content)
 
-        ### Only commit if there are changes
-        if not has_changes:
-            ### Return a dummy hash and False to indicate no changes
-            return ("", False) # TODO: Why do we need the hash here?
+            ### Only commit if there are changes
+            if not has_changes:
+                ### Return a dummy hash and False to indicate no changes
+                return ("", False) # TODO: Why do we need the hash here?
 
-        ### Stage the file
-        repo.index.add([config_file.name])
+            ### Stage the file
+            repo.index.add([config_file.name])
 
-        ### Create commit message
-        if message is None:
-            message = self._render_commit_message(device_name=device_name, group=group)
+            ### Create commit message
+            if message is None:
+                message = self._render_commit_message(device_name=device_name, group=group)
 
-        ### Commit
-        actor = Actor("KiwiSSH Backup System", "backup@kiwissh.local")
-        commit = repo.index.commit(message, author=actor, committer=actor)
+            ### Commit
+            actor = Actor("KiwiSSH Backup System", "backup@kiwissh.local")
+            commit = repo.index.commit(message, author=actor, committer=actor)
 
-        if self._has_remote_target(group):
-            push_ok = await self.push_to_remote(group=group)
-            if not push_ok:
-                logger.warning(
-                    "Local commit created for %s but push to remote failed (group: %s)",
-                    device_name,
-                    group,
-                )
+            if self._has_remote_target(group):
+                push_ok = self._push_to_remote_sync(group=group)
+                if not push_ok:
+                    logger.warning(
+                        "Local commit created for %s but push to remote failed (group: %s)",
+                        device_name,
+                        group,
+                    )
 
-        return (commit.hexsha, True)
+            return (commit.hexsha, True)
+
+    async def save_config(
+        self,
+        device_name: str,
+        config_content: str,
+        group: str,
+        message: str | None = None,
+    ) -> tuple[str, bool]:
+        """Save configuration to git repository without blocking the event loop."""
+        return await asyncio.to_thread(
+            self._save_config_sync,
+            device_name,
+            config_content,
+            group,
+            message,
+        )
 
     async def get_config_history(
         self,
@@ -418,7 +449,7 @@ class GitService:
         """
         raise NotImplementedError("Latest commit retrieval not yet implemented")
 
-    async def push_to_remote(self, group: str | None = None) -> bool:
+    def _push_to_remote_sync(self, group: str | None = None) -> bool:
         """
         Push local commits to remote repository.
 
@@ -444,73 +475,75 @@ class GitService:
 
         ### Iterate over target groups and attempt push if remote is configured
         for group_name in target_groups:
-            repo = self._ensure_repo(group_name)
+            lock = self._get_repo_lock(group_name)
+            with lock:
+                repo = self._ensure_repo(group_name)
 
-            ### Step 0: Check remote target
-            try:
-                remote_url, branch_name = self._resolve_remote_target(group_name)
-            except ValueError as ex:
-                logger.warning("Remote push skipped for group %s: %s", group_name, ex)
-                continue
-
-            if not self._has_commits(repo):
-                logger.warning(
-                    "Remote push skipped for group %s because repository has no commits",
-                    group_name,
-                )
-                continue
-
-            ### Step 1: Push commits to remote and handle errors
-            try:
-                attempted_push = True
-                remote = self._ensure_origin_remote(repo, remote_url)
-
+                ### Step 0: Check remote target
                 try:
-                    current_branch = repo.active_branch.name
-                except TypeError:
-                    current_branch = None
-
-                ### Switch to target branch if not already on it
-                if current_branch != branch_name:
-                    repo.git.checkout("-B", branch_name)
-
-                push_results = remote.push(refspec=f"{branch_name}:{branch_name}")
-                if not push_results:
-                    overall_success = False
-                    logger.error("Remote push returned no result for group %s", group_name)
+                    remote_url, branch_name = self._resolve_remote_target(group_name)
+                except ValueError as ex:
+                    logger.warning("Remote push skipped for group %s: %s", group_name, ex)
                     continue
 
-                errors = [
-                    result.summary
-                    for result in push_results
-                    if self._push_result_has_error(result)
-                ]
+                if not self._has_commits(repo):
+                    logger.warning(
+                        "Remote push skipped for group %s because repository has no commits",
+                        group_name,
+                    )
+                    continue
 
-                if errors:
+                ### Step 1: Push commits to remote and handle errors
+                try:
+                    attempted_push = True
+                    remote = self._ensure_origin_remote(repo, remote_url)
+
+                    try:
+                        current_branch = repo.active_branch.name
+                    except TypeError:
+                        current_branch = None
+
+                    ### Switch to target branch if not already on it
+                    if current_branch != branch_name:
+                        repo.git.checkout("-B", branch_name)
+
+                    push_results = remote.push(refspec=f"{branch_name}:{branch_name}")
+                    if not push_results:
+                        overall_success = False
+                        logger.error("Remote push returned no result for group %s", group_name)
+                        continue
+
+                    errors = [
+                        result.summary
+                        for result in push_results
+                        if self._push_result_has_error(result)
+                    ]
+
+                    if errors:
+                        overall_success = False
+                        logger.error(
+                            "Remote push failed for group %s: %s",
+                            group_name,
+                            "; ".join(errors),
+                        )
+                        continue
+
+                    ### Relief..
+                    logger.info(
+                        "Successfully pushed group %s to remote branch %s",
+                        group_name,
+                        branch_name,
+                    )
+                except GitCommandError as ex:
                     overall_success = False
                     logger.error(
                         "Remote push failed for group %s: %s",
                         group_name,
-                        "; ".join(errors),
+                        ex,
                     )
-                    continue
-
-                ### Relief..
-                logger.info(
-                    "Successfully pushed group %s to remote branch %s",
-                    group_name,
-                    branch_name,
-                )
-            except GitCommandError as ex:
-                overall_success = False
-                logger.error(
-                    "Remote push failed for group %s: %s",
-                    group_name,
-                    ex,
-                )
-            except Exception as ex:
-                overall_success = False
-                logger.error("Remote push failed for group %s: %s", group_name, ex)
+                except Exception as ex:
+                    overall_success = False
+                    logger.error("Remote push failed for group %s: %s", group_name, ex)
 
         if not attempted_push:
             logger.info("Remote push skipped because no configured remotes had commits to push")

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -469,6 +469,40 @@ class SSHService:
         ### Return normalized command output
         return self._sanitize_command_output(raw, command, prompt_patterns)
 
+    @staticmethod
+    def _normalize_interactive_input_text(input_text: str) -> str:
+        """Normalize common escaped control-sequence forms for interactive input."""
+        if input_text in {"\\n", "\\r", "\\r\\n"}:
+            return input_text.encode("utf-8").decode("unicode_escape")
+        return input_text
+
+    @staticmethod
+    def _resolve_interactive_inputs(command_def: dict[str, Any]) -> list[str]:
+        """Resolve interactive input sequence for command steps.
+
+        Supported format:
+        - then: ["value1", "value2", ...]
+        """
+        ### Check if input is a list
+        then_value = command_def.get("then")
+        if not isinstance(then_value, list):
+            raise RuntimeError(
+                "Step failed: 'then' must be a YAML list. "
+                "Use 'then: [\"value1\", \"value2\", ...]'"
+            )
+
+        raw_inputs = ["" if value is None else str(value) for value in then_value]
+
+        if not raw_inputs:
+            raise RuntimeError("Step failed: interactive input sequence is empty")
+
+        ### Set max. length of 5 for now
+        ## TODO: Don't hardcode this?
+        if len(raw_inputs) > 5:
+            raise RuntimeError("Step failed: interactive input supports a maximum of 5 entries")
+
+        return [SSHService._normalize_interactive_input_text(value) for value in raw_inputs]
+
     async def _run_command_phase(
         self,
         process: asyncssh.SSHClientProcess,

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -516,10 +516,9 @@ class SSHService:
     ) -> list[dict[str, Any]]:
         """Run one command phase and return captured output chunks.
 
-        Supported step types:
-        - command (default): send `command` and optionally wait for prompt
-        - send_input: send `input` text and optionally wait for prompt
-                    (if `input` is omitted, device password is sent)
+        Supported step modes:
+        - command: send `command` and optionally skip wait for prompt
+        - command + then: send `command`, then send up to five interactive inputs and optionally skip wait for prompt
 
         A chunk contains:
         - command: command string
@@ -530,9 +529,8 @@ class SSHService:
         captured_outputs: list[dict[str, Any]] = []
 
         for command_def in commands:
-            ### Get type of the step
-            step_type = str(command_def.get("type") or "command")
-            step_type = step_type.strip().lower()
+            command = str(command_def.get("command") or "").strip()
+            has_then = "then" in command_def
 
             metadata = bool(command_def.get("metadata", False))
             wait_for_prompt = bool(command_def.get("wait_for_prompt", True))
@@ -544,23 +542,25 @@ class SSHService:
                     "cannot be used together with 'metadata: true'"
                 )
 
-            ### Fire send input steps
-            if step_type == "send_input":
+            ### Fire interactive input steps (`command` + `then`)
+            if has_then:
                 try:
-                    ### Resolve input text for send_input steps
-                    ## If the step does not define explicit input, reuse resolved..
-                    ## ..device password for backward compatibility.
-                    if command_def.get("input") is None:
-                        if password is None or not str(password).strip():
-                            raise RuntimeError(
-                                "Step failed: send_input requires explicit 'input' when no device password is configured"
-                            )
-                        input_text = str(password)
-                    else:
-                        input_text = str(command_def.get("input"))
+                    ### Some devices require a command before interactive input (e.g. 'enable')
+                    if command:
+                        process.stdin.write(f"{command}\n")
+                        await asyncio.sleep(0.1)
 
-                    ### Send the resolved input as one line.
-                    process.stdin.write(f"{input_text}\n")
+                    interactive_inputs = self._resolve_interactive_inputs(command_def)
+
+                    ### Send all interactive inputs in sequence, then wait for prompt once
+                    for index, input_text in enumerate(interactive_inputs, start=1):
+                        if input_text.endswith(("\n", "\r")):
+                            process.stdin.write(input_text)
+                        else:
+                            process.stdin.write(f"{input_text}\n")
+
+                        if index < len(interactive_inputs):
+                            await asyncio.sleep(0.1)
 
                     ### Optionally wait for the prompt after sending input to ensure the device is ready for the next command
                     if wait_for_prompt:
@@ -575,17 +575,11 @@ class SSHService:
                         await asyncio.sleep(0.1)
                 except Exception as ex:
                     if required:
-                        raise RuntimeError("Step failed: send_input") from ex
-                    logger.warning("Optional step failed 'send_input': %s", ex)
+                        raise RuntimeError("Step failed: interactive input") from ex
+                    logger.warning("Optional interactive-input step failed: %s", ex)
                 continue
 
-            ### Raise error for unsupported step types
-            if step_type != "command":
-                ex = ValueError(f"Unsupported command step type '{step_type}'")
-                raise RuntimeError(str(ex)) from ex
-
             ### Fire command steps
-            command = str(command_def.get("command") or "").strip()
             if not command:
                 raise RuntimeError("Step failed: command is empty")
 

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -395,6 +395,7 @@ class SSHService:
         raw_output: str,
         command: str,
         prompt_patterns: list[re.Pattern[str]],
+        known_commands: list[str] | None = None,
     ) -> str:
         """Normalize interactive shell output and strip prompt/command echo."""
         ### Strip terminal control sequences and normalize line endings/backspaces.
@@ -437,8 +438,36 @@ class SSHService:
         while lines and SSHService._line_matches_prompt(lines[-1], prompt_patterns):
             lines.pop()
 
+        ### Remove trailing echoed command lines such as '<prompt>#show inventory'
+        command_candidates = [value.strip() for value in (known_commands or []) if value and value.strip()]
+        while lines and SSHService._line_matches_prompt_with_known_command(lines[-1], command_candidates):
+            lines.pop()
+
+        while lines and not lines[-1].strip():
+            lines.pop()
+
         ### Return only the cleaned command body for storage and post-processing.
         return "\n".join(lines).strip()
+
+    @staticmethod
+    def _line_matches_prompt_with_known_command(
+        line: str,
+        known_commands: list[str],
+    ) -> bool:
+        """Check whether a line ends with an echoed known command after a prompt marker."""
+        if not known_commands:
+            return False
+
+        normalized_line = ANSI_ESCAPE_RE.sub("", line).replace("\r", "").replace("\x08", "")
+        stripped_line = normalized_line.strip()
+        if not stripped_line:
+            return False
+
+        for known_command in known_commands:
+            if re.search(rf"[>#]\s*{re.escape(known_command)}\s*$", stripped_line):
+                return True
+
+        return False
 
     async def _execute_shell_command(
         self,
@@ -448,8 +477,18 @@ class SSHService:
         wait_for_prompt: bool,
         prompt_patterns: list[re.Pattern[str]],
         pagination_rules: list[PaginationRule],
+        known_commands: list[str] | None = None,
     ) -> str:
         """Execute a single command in an interactive shell session."""
+        ### Drain any stale prompt bytes before issuing the next command
+        stale_output = await self._read_trailing_output(process.stdout, idle_timeout=0.02, max_chunks=8)
+        if stale_output.strip():
+            logger.debug(
+                "Discarded %d stale shell byte(s) before command '%s' to avoid output desync",
+                len(stale_output),
+                command,
+            )
+
         ### Send the command to the shell
         process.stdin.write(f"{command}\n")
 
@@ -467,7 +506,7 @@ class SSHService:
         )
 
         ### Return normalized command output
-        return self._sanitize_command_output(raw, command, prompt_patterns)
+        return self._sanitize_command_output(raw, command, prompt_patterns, known_commands=known_commands)
 
     @staticmethod
     def _normalize_interactive_input_text(input_text: str) -> str:
@@ -526,6 +565,11 @@ class SSHService:
         - show_command_in_config: whether command header is embedded before output in config body
         """
         captured_outputs: list[dict[str, Any]] = []
+        phase_commands = [ # Save commands used in a list
+            str(step.get("command") or "").strip()
+            for step in commands
+            if str(step.get("command") or "").strip()
+        ]
 
         for command_def in commands:
             command = str(command_def.get("command") or "").strip()
@@ -590,6 +634,7 @@ class SSHService:
                     wait_for_prompt=wait_for_prompt,
                     prompt_patterns=prompt_patterns,
                     pagination_rules=pagination_rules,
+                    known_commands=phase_commands,
                 )
                 if capture_output and output:
                     captured_outputs.append({

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -38,6 +38,10 @@ DEFAULT_PAGINATION_PATTERNS = [
     re.compile(r"^\s*Press <space> to continue(?:, q to quit)?\s*$", re.IGNORECASE),
 ]
 DEFAULT_PAGINATION_RESPONSE = " "
+READ_CHUNK_SIZE = 4096
+READ_POLL_INTERVAL_SECONDS = 1.0
+LARGE_OUTPUT_TIMEOUT_THRESHOLD_BYTES = 256 * 1024
+LARGE_OUTPUT_INACTIVITY_TIMEOUT_SECONDS = 90
 
 PaginationRule = tuple[re.Pattern[str], str]
 
@@ -355,7 +359,10 @@ class SSHService:
 
             ### Read the next chunk of output with a short timeout to allow for prompt detection
             try:
-                chunk = await asyncio.wait_for(stream.read(256), timeout=min(remaining, 1.0))
+                chunk = await asyncio.wait_for(
+                    stream.read(READ_CHUNK_SIZE),
+                    timeout=min(remaining, READ_POLL_INTERVAL_SECONDS),
+                )
             except asyncio.TimeoutError:
                 ### No new bytes in this polling window; keep waiting until overall deadline
                 continue
@@ -365,6 +372,18 @@ class SSHService:
 
             ### Append the new chunk to the buffer and continue checking for patterns
             buffer += chunk
+
+            ### Large outputs on slower devices can pause for longer between chunks
+            if (
+                len(buffer) >= LARGE_OUTPUT_TIMEOUT_THRESHOLD_BYTES
+                and timeout_seconds < LARGE_OUTPUT_INACTIVITY_TIMEOUT_SECONDS
+            ):
+                timeout_seconds = LARGE_OUTPUT_INACTIVITY_TIMEOUT_SECONDS
+                logger.debug(
+                    "Extended prompt inactivity timeout to %ds for large output stream (%d bytes buffered)",
+                    timeout_seconds,
+                    len(buffer),
+                )
 
             ### Timeout tracks inactivity, not total command runtime
             inactivity_deadline = loop.time() + timeout_seconds
@@ -379,7 +398,7 @@ class SSHService:
         trailing = ""
         for _ in range(max_chunks):
             try:
-                chunk = await asyncio.wait_for(stream.read(256), timeout=idle_timeout)
+                chunk = await asyncio.wait_for(stream.read(READ_CHUNK_SIZE), timeout=idle_timeout)
             except asyncio.TimeoutError:
                 break
 

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -863,56 +863,33 @@ class SSHService:
                 capture_output=False,
             )
 
-            ### Request graceful shell exit first; require forced close as fallback
-            process.stdin.write("exit\n")
-
         finally:
-            ### Wait briefly for graceful shell exit, force close only when it hangs
-            wait_timeout_seconds = 1.5
-            shell_closed = False
+            ### Always force-close local shell handle; if already closed this isn't needed
+            forced_close_wait_timeout_seconds = 1.5
+            try:
+                close = getattr(process, "close", None)
+                if callable(close):
+                    close()
+                else:
+                    channel = getattr(process, "channel", None)
+                    if channel is None and hasattr(process, "stdin"):
+                        channel = getattr(process.stdin, "channel", None)
+                    if channel is not None:
+                        channel.close()
+            except Exception as ex:
+                logger.debug(
+                    "Forced shell close failed for vendor '%s' (%s: %s); continuing outer SSH connection cleanup",
+                    vendor_id,
+                    ex.__class__.__name__,
+                    ex,
+                )
 
-            wait = getattr(process, "wait", None)
-            if callable(wait):
+            wait_closed = getattr(process, "wait_closed", None)
+            if callable(wait_closed):
                 try:
-                    await asyncio.wait_for(wait(), timeout=wait_timeout_seconds)
-                    shell_closed = True
-                    logger.debug("Interactive shell exited cleanly for vendor '%s'", vendor_id)
-                except asyncio.TimeoutError:
-                    logger.debug("Interactive shell did not exit in %.1fs for vendor '%s'; forcing close", wait_timeout_seconds, vendor_id)
-                except Exception as ex:
-                    logger.debug(
-                        "Graceful shell-exit wait failed for vendor '%s' (%s: %s); proceeding with forced-close fallback",
-                        vendor_id,
-                        ex.__class__.__name__,
-                        ex,
-                    )
-
-            ### Force close section
-            if not shell_closed:
-                try:
-                    close = getattr(process, "close", None)
-                    if callable(close):
-                        close()
-                    else:
-                        channel = getattr(process, "channel", None)
-                        if channel is None and hasattr(process, "stdin"):
-                            channel = getattr(process.stdin, "channel", None)
-                        if channel is not None:
-                            channel.close()
-                except Exception as ex:
-                    logger.debug(
-                        "Forced shell close failed for vendor '%s' (%s: %s); continuing outer SSH connection cleanup",
-                        vendor_id,
-                        ex.__class__.__name__,
-                        ex,
-                    )
-
-                wait_closed = getattr(process, "wait_closed", None)
-                if callable(wait_closed):
-                    try:
-                        await asyncio.wait_for(wait_closed(), timeout=wait_timeout_seconds)
-                    except Exception:
-                        pass
+                    await asyncio.wait_for(wait_closed(), timeout=forced_close_wait_timeout_seconds)
+                except Exception:
+                    pass
 
         non_metadata_outputs: list[str] = []
         for chunk in captured_output:

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -832,35 +832,36 @@ class SSHService:
             ### Wait for the initial prompt to ensure the shell is ready before sending commands
             await self._read_until_patterns(process.stdout, prompt_patterns, default_timeout)
 
-            ### Run pre_backup commands (required for session setup consistency)
+            ### Run commands
+            ## pre_backup
             await self._run_command_phase(
                 process=process,
                 commands=pre_backup_commands,
                 default_timeout=default_timeout,
-                password=password,
                 prompt_patterns=prompt_patterns,
                 pagination_rules=pagination_rules,
                 capture_output=False,
             )
 
+            ## backup
             captured_output = await self._run_command_phase(
                 process=process,
                 commands=backup_commands,
                 default_timeout=default_timeout,
-                password=password,
                 prompt_patterns=prompt_patterns,
                 pagination_rules=pagination_rules,
                 capture_output=True,
             )
 
+            ## post_backup
             await self._run_command_phase(
                 process=process,
                 commands=post_backup_commands,
                 default_timeout=default_timeout,
-                password=password,
                 prompt_patterns=prompt_patterns,
                 pagination_rules=pagination_rules,
                 capture_output=False,
+                required=False, # Set to false so backup capture can still succeed even if post_backup fails
             )
 
         finally:

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -604,13 +604,17 @@ class SSHService:
                     "cannot be used together with 'metadata: true'"
                 )
 
+            if has_then and not command:
+                raise RuntimeError(
+                    "Step failed: 'then' requires a non-empty 'command' in the same step"
+                )
+
             ### Fire interactive input steps (`command` + `then`)
             if has_then:
                 try:
                     ### Some devices require a command before interactive input (e.g. 'enable')
-                    if command:
-                        process.stdin.write(f"{command}\n")
-                        await asyncio.sleep(0.1)
+                    process.stdin.write(f"{command}\n")
+                    await asyncio.sleep(0.1)
 
                     interactive_inputs = self._resolve_interactive_inputs(command_def)
 

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -1034,6 +1034,13 @@ class SSHService:
                     default_timeout=timeout_seconds,
                     password=device_password,
                 )
+                if attempt > 1:
+                    logger.warning(
+                        "Config fetch for device '%s' succeeded on retry attempt %d/%d",
+                        device.device_name,
+                        attempt,
+                        max_attempts,
+                    )
                 return config, metadata_output
             except asyncio.TimeoutError as ex:
                 ### Log timeout error if SSH connection times out or if waiting for command output exceeds timeout

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -508,7 +508,6 @@ class SSHService:
         process: asyncssh.SSHClientProcess,
         commands: list[dict[str, Any]],
         default_timeout: int,
-        password: str | None,
         prompt_patterns: list[re.Pattern[str]],
         pagination_rules: list[PaginationRule],
         capture_output: bool,
@@ -801,7 +800,6 @@ class SSHService:
         connection: asyncssh.SSHClientConnection,
         vendor_id: str,
         default_timeout: int,
-        password: str | None,
     ) -> tuple[str, str | None]:
         """Collect configuration and metadata from device via vendor-defined command phases."""
         ### Get command sets for the vendor (pre_backup, backup, post_backup)
@@ -1060,7 +1058,6 @@ class SSHService:
                     connection=connection,
                     vendor_id=vendor_id,
                     default_timeout=timeout_seconds,
-                    password=device_password,
                 )
                 if attempt > 1:
                     logger.warning(

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -830,7 +830,15 @@ class SSHService:
             process.stdin.write("\n")
 
             ### Wait for the initial prompt to ensure the shell is ready before sending commands
-            await self._read_until_patterns(process.stdout, prompt_patterns, default_timeout)
+            try:
+                await self._read_until_patterns(process.stdout, prompt_patterns, default_timeout)
+            except asyncio.TimeoutError:
+                logger.debug(
+                    "Initial prompt wait timed out for vendor '%s'; retrying once after additional newline",
+                    vendor_id,
+                )
+                process.stdin.write("\n")
+                await self._read_until_patterns(process.stdout, prompt_patterns, default_timeout)
 
             ### Run commands
             ## pre_backup

--- a/backend/config/vendors/OS_TYPES.md
+++ b/backend/config/vendors/OS_TYPES.md
@@ -35,8 +35,8 @@ KiwiSSH needs read-write privilege in order to execute `config paging disable`.
 
 There are two models for Fortinet devices:
 
-- fortigate: for the FortiGate firewalls
-- fortios: for VM-Based appliances (FortiManager, FortiADC, FortiAnalyzer...)
+- `fortigate`: for the FortiGate firewalls
+- `fortios`: for VM-Based appliances (FortiManager, FortiADC, FortiAnalyzer...)
 
 ### Notes for both device types
 
@@ -68,7 +68,7 @@ set system login user kiwissh authentication plain-text-password "yourpasswordhe
 
 ## TrueNAS
 
-The TrueNAS vendor YAML file currently uses the `sqlite3` command without `sudo` to fetch the configuration from the database. For TrueNAS SCALE machines, make sure the user you use to connect can run this command, or if needed, with passwordless `sudo`. Try putting this in `/etc/sudoers`:
+The TrueNAS vendor YAML file currently uses the `sqlite3` command without `sudo` to fetch the configuration from the database. For TrueNAS SCALE machines, make sure the user you use to connect can run this command, or if needed, with passwordless `sudo`. Add the following to your sudoers file via `sudo visudo`:
 
 `kiwissh ALL=(ALL) NOPASSWD: /usr/bin/sqlite3 file\:///data/freenas-v1.db?mode\=ro&immutable\=1 .dump`
 

--- a/backend/config/vendors/a10_acos.yaml
+++ b/backend/config/vendors/a10_acos.yaml
@@ -13,12 +13,14 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
   pre_backup: 
+    - command: enable
+      then: [""] # <- set enable password here if needed
     - command: "terminal length 0"
     - command: "terminal width 0"
 
@@ -35,12 +37,16 @@ commands:
       metadata: true
     - command: "show partition-config all"
       show_command_in_config: true
-    - command: "show running-config all-partitions"
+    - command: "show running-config"
       show_command_in_config: true
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit" # exit enable
+      then:
+        - "exit" # exit session
+        - "Y"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/cisco_aireos.yaml
+++ b/backend/config/vendors/cisco_aireos.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -35,9 +35,8 @@ commands:
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
   post_backup:
-    - type: "send_input"
-      command: "logout"
-      input: "n"
+    - command: "logout"
+      then: ["n"]
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/cisco_ios.yaml
+++ b/backend/config/vendors/cisco_ios.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -42,6 +42,7 @@ commands:
   post_backup:
     - command: "terminal length 24"
       description: "Restore paging"
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/cisco_nxos.yaml
+++ b/backend/config/vendors/cisco_nxos.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -34,7 +34,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/fortinet_fortigate.yaml
+++ b/backend/config/vendors/fortinet_fortigate.yaml
@@ -18,8 +18,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -46,15 +46,17 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate
 processing:
-  # strip_patterns:
-  #   - "^% Invalid input detected at '\\^' marker\\.$"
-  #   - "^\\s+\\^$"
-  #   - "^#config-version="
+  strip_patterns:
+    # - "^% Invalid input detected at '\\^' marker\\.$"
+    # - "^\\s+\\^$"
+    # - "^#config-version="
+    # - "^conf_file_ver=.*$"
 
   # config_start: "^config "
   # config_end: "^end$"

--- a/backend/config/vendors/fortinet_fortios.yaml
+++ b/backend/config/vendors/fortinet_fortios.yaml
@@ -17,8 +17,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -37,7 +37,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/hp_procurve.yaml
+++ b/backend/config/vendors/hp_procurve.yaml
@@ -9,47 +9,55 @@ vendor:
 ### Session-level behavior
 session:
   comment_prefix: "! "
-  prompt: '^(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})$' # TODO!
   pagination:
     enabled: true
     patterns:
-      - pattern: '^Press any key to continue(\e\[\??\d+(;\d+)*[A-Za-z])*$'
+      - pattern: '^Press any key to continue(\\e\\[\\??\\d+(;\\d+)*[A-Za-z])*$'
         response: " "
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
   pre_backup: 
     - command: "no page"
-    # - type: "send_input"
-    #   command: "enable"
+    # - command: "enable"
+      # then:
+      #   - "<enable user>"
+      #   - "<enable password>"
 
   ### Main backup command(s)
   ## Commands whose output becomes the stored configuration
   backup:
     - command: "show version"
       metadata: true
-    - command: "show modules"
+    - command: "show module" # not supported on all models
       metadata: true
-    - command: "show interface transceiver"
+    - command: "show interfaces transceiver" # not supported on all models
       metadata: true
+    # - command: "show tech transceivers" # older models
+    #   metadata: true
+    # - command: "show interfaces brief"
+    #   metadata: true
     - command: "show flash"
       metadata: true
     - command: "show system-information" # not supported on all models
       metadata: true
-    - command: "show system-information" # not supported on all models
-      metadata: true
+    # - command: "show system information" # not supported on all models
+    #   metadata: true
     - command: "show running-config"
       show_command_in_config: true
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
   post_backup: 
-    - command: "logout\ny\nn"
+    - command: "logout"
+      then:
+        - "y"
+        - "n"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/juniper_junos.yaml
+++ b/backend/config/vendors/juniper_junos.yaml
@@ -12,8 +12,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -26,7 +26,7 @@ commands:
   backup:
     - command: "show version"
       metadata: true
-    # - comamnd: "show chassis fabric reachability" # only for mx960
+    # - command: "show chassis fabric reachability" # only for mx960
     #   metadata: true
     # - command: "show virtual-chassis" # for ^(ex22|ex3[34]|ex4|ex8|qfx)$
     #   metadata: true
@@ -43,7 +43,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/openwrt.yaml
+++ b/backend/config/vendors/openwrt.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -34,7 +34,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/opnsense.yaml
+++ b/backend/config/vendors/opnsense.yaml
@@ -12,8 +12,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -30,7 +30,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/perle_iolan.yaml
+++ b/backend/config/vendors/perle_iolan.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -31,7 +31,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/pfsense.yaml
+++ b/backend/config/vendors/pfsense.yaml
@@ -12,8 +12,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -27,7 +27,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/sonic_enterprise.yaml
+++ b/backend/config/vendors/sonic_enterprise.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -30,7 +30,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/truenas.yaml
+++ b/backend/config/vendors/truenas.yaml
@@ -12,8 +12,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -30,7 +30,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/ubiquiti_unifi.yaml
+++ b/backend/config/vendors/ubiquiti_unifi.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -38,7 +38,8 @@ commands:
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/backend/config/vendors/watchguard_firewareos.yaml
+++ b/backend/config/vendors/watchguard_firewareos.yaml
@@ -13,8 +13,8 @@ session:
 
 ### Commands to execute for backup
 ## Supported step types in command phases:
-## - command (default): sends command text
-## - send_input: sends arbitrary input (defaults to resolved device password when input is omitted)
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
 commands:
   ### Pre-backup commands (prepare the session) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
@@ -23,14 +23,14 @@ commands:
   ### Main backup command(s)
   ## Commands whose output becomes the stored configuration
   backup:
-    - type: "send_input"
+    - command: "yes"
       description: "Handle Logon Disclaimer added in XTM 11.9.3"
-      input: "yes"
     - command: "show sysinfo"
 
   ### Post-backup commands (cleanup) (OPTIONAL)
   ## Command outputs aren't saved in stored configuration
-  post_backup: []
+  post_backup:
+    - command: "exit"
 
 ### Configuration processing rules
 ## Processing reduces diff noise and trims non-config boilerplate

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -9,6 +9,9 @@ services:
     volumes:
       ### Required: Mount the kiwissh.yaml into the container
       - /PATH_TO_CONFIG/kiwissh.yaml:/config/kiwissh.yaml
+      ### Required: Mount internal "git.local_path" to a volume or bind mount
+      ## CRITICAL: IF YOU DO NOT MOUNT THIS FOLDER, ALL LOCAL BACKUPS ARE DELETED ON CONTAINER RESTART!
+      - /PATH_TO_BACKUPS/kiwissh_backups/:/config/backups/
       ### Optional: Mount source file if used
       # - /PATH_TO_CONFIG/devices.csv:/config/sources/devices.csv
       ### Optional: Mount your own custom vendor files or ssh_profiles to the /config folder

--- a/frontend/src/api/backups.ts
+++ b/frontend/src/api/backups.ts
@@ -15,14 +15,16 @@ export const backupApi = {
   async getJobs(
     deviceName?: string,
     status?: string,
-    limit: number = 5000,
+    limit: number = 200,
     offset: number = 0,
     jobId?: string,
+    includeMetadata: boolean = false,
   ): Promise<BackupJobsResponse> {
     const params: Record<string, string | number> = { limit, offset }
     if (deviceName) params.device_name = deviceName
     if (status) params.status = status
     if (jobId) params.job_id = jobId
+    if (includeMetadata) params.include_metadata = true
     const response = await api.get<BackupJobsResponse>("/backups/jobs", { params })
     return response.data
   },

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,8 +7,8 @@ import router from "./router"
 import "./style.css"
 
 // Versions
-export const APP_VERSION = "1.2.0" // KiwiSSH backend + frontend bundled together
-export const FRONTEND_VERSION = "1.2.0" // Frontend version only
+export const APP_VERSION = "2.0.0" // KiwiSSH backend + frontend bundled together
+export const FRONTEND_VERSION = "1.2.1" // Frontend version only
 
 function applyInitialTheme(): void {
 	const themeStorageKey = "kiwissh-theme"

--- a/frontend/src/stores/jobs.ts
+++ b/frontend/src/stores/jobs.ts
@@ -9,6 +9,7 @@ interface JobsQueryState {
   limit: number
   offset: number
   jobId?: string
+  includeMetadata: boolean
 }
 
 export const useJobsStore = defineStore("jobs", () => {
@@ -26,8 +27,9 @@ export const useJobsStore = defineStore("jobs", () => {
   const totalNoChangesJobs = ref(0)
   const avgDurationSeconds = ref<number | null>(null)
   const lastQuery = ref<JobsQueryState>({
-    limit: 5000,
+    limit: 200,
     offset: 0,
+    includeMetadata: false,
   })
 
   let refreshTimer: ReturnType<typeof setInterval> | null = null
@@ -63,8 +65,30 @@ export const useJobsStore = defineStore("jobs", () => {
     }
   }
 
+  // Map API job record to internal job status format
+  function mapJobRecord(job: BackupJobRecord): BackupJobStatus {
+    return {
+      job_id: job.job_id,
+      device_name: job.device_name,
+      group: job.group,
+      status: job.status,
+      timestamp: new Date(job.timestamp).getTime(),
+      message: job.error_message || getJobMessage(job.status, job.device_name),
+      duration_seconds: job.duration_seconds ?? null,
+      metadata_output: job.metadata_output ?? null,
+      config_size_bytes: job.config_size_bytes ?? null,
+    }
+  }
+
   // Actions
-  async function loadJobs(deviceName?: string, status?: string, limit: number = 5000, offset: number = 0, jobId?: string) {
+  async function loadJobs(
+    deviceName?: string,
+    status?: string,
+    limit: number = 200,
+    offset: number = 0,
+    jobId?: string,
+    includeMetadata: boolean = false,
+  ) {
     loading.value = true
     error.value = null
     lastQuery.value = {
@@ -73,10 +97,11 @@ export const useJobsStore = defineStore("jobs", () => {
       limit,
       offset,
       jobId,
+      includeMetadata,
     }
 
     try {
-      const response = await backupApi.getJobs(deviceName, status, limit, offset, jobId)
+      const response = await backupApi.getJobs(deviceName, status, limit, offset, jobId, includeMetadata)
       const rawJobs = response.jobs || []
       totalJobs.value = typeof response.total_count === "number" ? response.total_count : rawJobs.length
       avgDurationSeconds.value = typeof response.avg_duration_seconds === "number"
@@ -95,23 +120,34 @@ export const useJobsStore = defineStore("jobs", () => {
         totalNoChangesJobs.value = rawJobs.filter((job: BackupJobRecord) => job.status === "no_changes").length
       }
 
-      // Convert database records to BackupJobStatus format
-      jobs.value = rawJobs.map((job: BackupJobRecord) => ({
-        job_id: job.job_id,
-        device_name: job.device_name,
-        group: job.group,
-        status: job.status, // "success", "failed", or "no_changes"
-        timestamp: new Date(job.timestamp).getTime(),
-        message: job.error_message || getJobMessage(job.status, job.device_name),
-        duration_seconds: job.duration_seconds ?? null,
-        metadata_output: job.metadata_output ?? null,
-        config_size_bytes: job.config_size_bytes ?? null,
-      }))
+      jobs.value = rawJobs.map((job: BackupJobRecord) => mapJobRecord(job))
     } catch (e) {
       error.value = e instanceof Error ? e.message : "Failed to load jobs"
       console.error("Error loading jobs:", e)
     } finally {
       loading.value = false
+    }
+  }
+
+  // Load details for a specific job and update the store
+  async function loadJobDetails(jobId: string): Promise<BackupJobStatus | null> {
+    try {
+      const response = await backupApi.getJobs(undefined, undefined, 1, 0, jobId, true)
+      const rawJob = response.jobs?.[0]
+      if (!rawJob) {
+        return null
+      }
+
+      const detailedJob = mapJobRecord(rawJob)
+      const existingIndex = jobs.value.findIndex((job) => job.job_id === detailedJob.job_id)
+      if (existingIndex !== -1) {
+        jobs.value[existingIndex] = detailedJob
+      }
+      selectedJob.value = detailedJob
+      return detailedJob
+    } catch (e) {
+      console.error("Error loading job details:", e)
+      return null
     }
   }
 
@@ -181,6 +217,7 @@ export const useJobsStore = defineStore("jobs", () => {
         lastQuery.value.limit,
         lastQuery.value.offset,
         lastQuery.value.jobId,
+        lastQuery.value.includeMetadata,
       )
     }, autoRefreshInterval.value * 1000) // Convert seconds to milliseconds
   }
@@ -251,6 +288,7 @@ export const useJobsStore = defineStore("jobs", () => {
     clearOldJobs,
     clearAllJobs,
     setSelectedJob,
+    loadJobDetails,
     clearError,
   }
 })

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -3,6 +3,7 @@ import { onMounted, onBeforeUnmount, computed, ref, watch } from "vue"
 import { useJobsStore } from "@/stores/jobs"
 import { useDevicesStore } from "@/stores/devices"
 import { backupApi } from "@/api/backups"
+import type { BackupJobStatus } from "@/types/backup"
 import LoadingSpinner from "@/components/LoadingSpinner.vue"
 
 const jobsStore = useJobsStore()
@@ -213,6 +214,14 @@ function formatSize(bytes?: number | null): string {
   const value = bytes / 1024 ** exponent
   const precision = value >= 10 || exponent === 0 ? 0 : 1
   return `${value.toFixed(precision)} ${units[exponent]}`
+}
+
+// Load job details when a job is selected
+async function handleSelectJob(job: BackupJobStatus) {
+  jobsStore.setSelectedJob(job)
+  if (!job.metadata_output) {
+    await jobsStore.loadJobDetails(job.job_id)
+  }
 }
 
 async function handleFlushDatabase() {
@@ -450,7 +459,7 @@ async function handleFlushDatabase() {
         <div
           v-for="job in filteredJobs"
           :key="job.job_id"
-          @click="jobsStore.setSelectedJob(job)"
+          @click="handleSelectJob(job)"
           class="card-hover cursor-pointer p-4"
         >
           <div class="flex items-start justify-between gap-4">


### PR DESCRIPTION
## Changes
- Reduced the amount of frontend fetches on "Jobs" page to increase load time
- Added device backup queue to queue backup jobs
- Improve pagination handling and timeout settings for large outputs
- Added config validation by config size diff and common CLI error patterns
- Updated logic to wait for initial prompt
- Enhanced command output sanitization with sent command handling

### BREAKING CHANGES
- Updated logic to handle interactive input. Your current vendor YAML files might become broken.

Deprecated old interactive input:
```yaml
- type: "send_input"
  command: "enable"
  input: "<input here>"
```

Please switch to:

```yaml
- command: "logout"
  then: ["y", "n"]
```

You can add up to five interactive commands in list form for the `then` parameter.

- Removed graceful shell exit. In order to gracefully close the SSH connection, specify the logout commands in `post_backup:` section in the vendor YAML. If not set, KiwiSSH will force-close the shell.
- Updated `/backups` API endpoint to use the new backup queue. Response has changed.