### PR TITLE
Merges variois changes into main

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """KiwiSSH Backend - Network Configuration Backup Application."""
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"

--- a/backend/app/api/routes/backups.py
+++ b/backend/app/api/routes/backups.py
@@ -1,6 +1,7 @@
 """Backup operation endpoints."""
 
 import logging
+from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, HTTPException, Depends, Query
 from sqlalchemy.orm import Session
 
@@ -211,6 +212,50 @@ async def get_device_backup_history(
             "total_count": 0,
             "limit": limit,
             "offset": offset,
+            "error": str(e),
+        }
+
+
+@router.get("/history/graph/{device_name}")
+async def get_device_backup_graph(
+    device_name: str,
+    days: int = Query(365, ge=1, le=3650, description="Number of days to include"),
+    tz_offset_minutes: int = Query(0, description="Timezone offset in minutes (Date.getTimezoneOffset())"),
+) -> dict:
+    """Get per-day backup counts for the last N days (graph-only endpoint)."""
+    device = await source_service.get_device(device_name)
+
+    if device is None:
+        raise HTTPException(status_code=404, detail=f"Device '{device_name}' not found")
+
+    try:
+        counts = await git_service.get_backup_graph_counts(
+            device_name,
+            group=device.group,
+            days=days,
+            tz_offset_minutes=tz_offset_minutes,
+        )
+        offset_delta = timedelta(minutes=-int(tz_offset_minutes))
+        now_utc = datetime.now(timezone.utc)
+        today_local = (now_utc + offset_delta).date()
+        start_date = today_local - timedelta(days=days - 1)
+        total = sum(int(item.get("count", 0)) for item in counts)
+
+        return {
+            "device_name": device_name,
+            "days": days,
+            "tz_offset_minutes": tz_offset_minutes,
+            "from": start_date.isoformat(),
+            "to": today_local.isoformat(),
+            "total": total,
+            "counts": counts,
+        }
+    except Exception as e:
+        return {
+            "device_name": device_name,
+            "days": days,
+            "tz_offset_minutes": tz_offset_minutes,
+            "counts": [],
             "error": str(e),
         }
 

--- a/backend/app/api/routes/backups.py
+++ b/backend/app/api/routes/backups.py
@@ -179,6 +179,7 @@ async def get_backup_job_status(job_id: str) -> dict:
 async def get_device_backup_history(
     device_name: str,
     limit: int | None = Query(None, ge=1, description="Maximum number of history entries to return. Omit for all."),
+    offset: int = Query(0, ge=0, description="Number of history entries to skip."),
 ) -> dict:
     """Get backup history for a device."""
     device = await source_service.get_device(device_name)
@@ -187,16 +188,29 @@ async def get_device_backup_history(
         raise HTTPException(status_code=404, detail=f"Device '{device_name}' not found")
 
     try:
-        history = await git_service.get_config_history(device_name, group=device.group, limit=limit)
+        total_count = await git_service.get_config_history_count(device_name, group=device.group)
+        history = await git_service.get_config_history(
+            device_name,
+            group=device.group,
+            limit=limit,
+            offset=offset,
+        )
         return {
             "device_name": device_name,
             "history": history,
             "count": len(history),
+            "total_count": total_count,
+            "limit": limit,
+            "offset": offset,
         }
     except Exception as e:
         return {
             "device_name": device_name,
             "history": [],
+            "count": 0,
+            "total_count": 0,
+            "limit": limit,
+            "offset": offset,
             "error": str(e),
         }
 
@@ -248,7 +262,7 @@ async def get_latest_config(device_name: str, commit: str | None = None) -> dict
         if commit:
             config = await git_service.get_config_at_commit(device_name, commit, group=device.group)
             ### Get commit info from history
-            history = await git_service.get_config_history(device_name, group=device.group, limit=None)
+            history = await git_service.get_config_history(device_name, group=device.group, limit=None, offset=0)
             commit_info = next((c for c in history if c["hash"] == commit), None)
 
             return {
@@ -261,7 +275,7 @@ async def get_latest_config(device_name: str, commit: str | None = None) -> dict
             }
         else:
             ### Get latest
-            history = await git_service.get_config_history(device_name, group=device.group, limit=1)
+            history = await git_service.get_config_history(device_name, group=device.group, limit=1, offset=0)
             if not history:
                 return {
                     "device_name": device_name,

--- a/backend/app/api/routes/devices.py
+++ b/backend/app/api/routes/devices.py
@@ -110,9 +110,7 @@ async def get_device(device_name: str, db: Session = Depends(get_db)) -> dict:
     ### Get backup count from git history
     backup_count = 0
     try:
-        history = await git_service.get_config_history(device_name, group=device.group, limit=None)
-        if history:
-            backup_count = len(history)
+        backup_count = await git_service.get_config_history_count(device_name, group=device.group)
     except Exception:
         pass
 

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -449,21 +449,36 @@ class BackupService:
             device_config = settings.get_device_config(device.group, device.device_name)
             protocol = str(device_config.get("protocol") or "ssh").strip().lower()
 
-            ### Get config from device via SSH or Telnet (or simulator)
-            if protocol == "telnet":
-                config, metadata_output = await telnet_service.get_config(
-                    device,
-                    device_config=device_config,
-                )
-            elif protocol == "ssh":
-                config, metadata_output = await ssh_service.get_config(
-                    device,
-                    device_config=device_config,
-                )
-            logger.debug(f"Got config for {device.device_name} ({len(config)} bytes)")
+            async def _fetch_config() -> tuple[str, str | None]:
+                if protocol == "telnet":
+                    return await telnet_service.get_config(
+                        device,
+                        device_config=device_config,
+                    )
+                if protocol == "ssh":
+                    return await ssh_service.get_config(
+                        device,
+                        device_config=device_config,
+                    )
+                raise RuntimeError(f"Unsupported protocol: {protocol}")
 
-            ### Validate config for obvious capture issues before saving to git
-            config_size = await asyncio.to_thread(self._validate_config_capture, device.device_name, config)
+            ### Get config from device via SSH or Telnet (or simulator)
+            for attempt in range(2):
+                config, metadata_output = await _fetch_config()
+                logger.debug(f"Got config for {device.device_name} ({len(config)} bytes)")
+                try:
+                    ### Validate config for obvious capture issues before saving to git
+                    config_size = await asyncio.to_thread(self._validate_config_capture, device.device_name, config)
+                    break
+                except ConfigCaptureTooSmallError as ex:
+                    if attempt == 0:
+                        logger.warning(
+                            "Config capture for %s appears too small; retrying once: %s",
+                            device.device_name,
+                            ex,
+                        )
+                        continue
+                    raise
 
             ### Save config to git (using device's group)
             commit_hash, has_changes = await git_service.save_config(

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -40,6 +40,14 @@ CLI_ERROR_PATTERNS = [
 ]
 
 
+class ConfigCaptureValidationError(RuntimeError):
+    """Base error for invalid config captures."""
+
+
+class ConfigCaptureTooSmallError(ConfigCaptureValidationError):
+    """Raised when captured config is suspiciously small."""
+
+
 class BackupService:
     """Service for orchestrating device backups."""
 
@@ -383,7 +391,7 @@ class BackupService:
         ### Raise error if CLI error patterns are detected
         error_signature = self._find_cli_error_signature(config)
         if error_signature:
-            raise RuntimeError(
+            raise ConfigCaptureValidationError(
                 f"Captured config appears invalid (CLI error detected): {error_signature}"
             )
 
@@ -392,7 +400,7 @@ class BackupService:
         if previous_size is not None and previous_size >= 8192: # Size in bytes
             minimum_expected_size = max(1024, int(previous_size * 0.20)) # equals to at least 20% of previous size or 1KB, whichever is larger
             if config_size < minimum_expected_size and non_empty_lines < 60:
-                raise RuntimeError(
+                raise ConfigCaptureTooSmallError(
                     "Captured config is suspiciously small compared to previous successful backup "
                     f"({config_size} bytes vs previous {previous_size} bytes)"
                 )

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -285,47 +285,55 @@ class GitService:
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         """Blocking git history lookup for a device config file."""
-        repo = self._ensure_repo(group)
-        commits: list[dict[str, Any]] = []
-        config_file = f"{device_name}.conf"
+        lock = self._get_repo_lock(group)
+        with lock:
+            ### Check if repo exists and has commits
+            repo = self._ensure_repo(group)
+            if not self._has_commits(repo):
+                return []
+            commits: list[dict[str, Any]] = []
+            config_file = f"{device_name}.conf"
 
-        commit_kwargs: dict[str, Any] = {"paths": config_file}
-        if limit is not None:
-            commit_kwargs["max_count"] = limit
-        if offset > 0:
-            commit_kwargs["skip"] = offset
+            commit_kwargs: dict[str, Any] = {"paths": config_file}
+            if limit is not None:
+                commit_kwargs["max_count"] = limit
+            if offset > 0:
+                commit_kwargs["skip"] = offset
 
-        for commit in repo.iter_commits(**commit_kwargs):
-            ### Get file size at this commit
-            file_size_bytes = 0
             try:
-                file_size_bytes = (commit.tree / config_file).size
-            except KeyError:
-                file_size_bytes = 0
+                for commit in repo.iter_commits(**commit_kwargs):
+                    ### Get file size at this commit
+                    file_size_bytes = 0
+                    try:
+                        file_size_bytes = (commit.tree / config_file).size
+                    except KeyError:
+                        file_size_bytes = 0
 
-            commits.append({
-                "hash": commit.hexsha,
-                "short_hash": commit.hexsha[:7],
-                "message": commit.message.strip(),
-                "author": commit.author.name,
-                "date": datetime.fromtimestamp(commit.committed_date, tz=timezone.utc),
-                "timestamp": datetime.fromtimestamp(commit.committed_date, tz=timezone.utc).isoformat(),
-                "file_size_bytes": file_size_bytes,
-                "version_number": 0,  # Will be set after we know total count
-            })
+                    commits.append({
+                        "hash": commit.hexsha,
+                        "short_hash": commit.hexsha[:7],
+                        "message": commit.message.strip(),
+                        "author": commit.author.name,
+                        "date": datetime.fromtimestamp(commit.committed_date, tz=timezone.utc),
+                        "timestamp": datetime.fromtimestamp(commit.committed_date, tz=timezone.utc).isoformat(),
+                        "file_size_bytes": file_size_bytes,
+                        "version_number": 0,  # Will be set after we know total count
+                    })
+            except Exception:
+                return []
 
-        total_count = len(commits)
-        try:
-            total_count = int(repo.git.rev_list("--count", "HEAD", "--", config_file).strip())
-        except (ValueError, GitCommandError):
             total_count = len(commits)
+            try:
+                total_count = int(repo.git.rev_list("--count", "HEAD", "--", config_file).strip())
+            except (ValueError, GitCommandError):
+                total_count = len(commits)
 
-        ### Assign version numbers globally - oldest commit = 1, newest = N
-        ### Commits are newest first, so reverse the numbering
-        for idx, commit in enumerate(commits):
-            commit["version_number"] = max(0, total_count - (offset + idx))
+            ### Assign version numbers globally - oldest commit = 1, newest = N
+            ### Commits are newest first, so reverse the numbering
+            for idx, commit in enumerate(commits):
+                commit["version_number"] = max(0, total_count - (offset + idx))
 
-        return commits
+            return commits
 
     async def get_config_history(
         self,
@@ -350,12 +358,17 @@ class GitService:
 
     def _get_config_history_count_sync(self, device_name: str, group: str) -> int:
         """Return commit count for a device config file using git rev-list."""
-        repo = self._ensure_repo(group)
-        config_file = f"{device_name}.conf"
-        try:
-            return int(repo.git.rev_list("--count", "HEAD", "--", config_file).strip())
-        except (ValueError, GitCommandError):
-            return 0
+        lock = self._get_repo_lock(group)
+        with lock:
+            ### Check if repo exists and has commits
+            repo = self._ensure_repo(group)
+            if not self._has_commits(repo):
+                return 0
+            config_file = f"{device_name}.conf"
+            try:
+                return int(repo.git.rev_list("--count", "HEAD", "--", config_file).strip())
+            except (ValueError, GitCommandError):
+                return 0
 
     async def get_config_history_count(self, device_name: str, group: str) -> int:
         """Get configuration history count without loading full history."""
@@ -442,20 +455,23 @@ class GitService:
         Raises:
             ValueError: If commit not found
         """
-        repo = self._ensure_repo(group)
+        lock = self._get_repo_lock(group)
+        with lock:
+            ### Check that repo exists
+            repo = self._ensure_repo(group)
 
-        try:
-            commit = repo.commit(commit_hash)
-        except Exception as e:
-            raise ValueError(f"Commit {commit_hash} not found") from e
+            try:
+                commit = repo.commit(commit_hash)
+            except Exception as e:
+                raise ValueError(f"Commit {commit_hash} not found") from e
 
-        ### Get all files in the commit
-        config_file = f"{device_name}.conf"
-        for item in commit.tree.traverse():
-            if item.path == config_file:
-                return item.data_stream.read().decode("utf-8")
+            ### Get all files in the commit
+            config_file = f"{device_name}.conf"
+            for item in commit.tree.traverse():
+                if item.path == config_file:
+                    return item.data_stream.read().decode("utf-8")
 
-        raise ValueError(f"No config found for {device_name} at commit {commit_hash}")
+            raise ValueError(f"No config found for {device_name} at commit {commit_hash}")
 
     async def get_diff(
         self,
@@ -476,36 +492,39 @@ class GitService:
         Returns:
             BackupDiff object with diff information
         """
-        repo = self._ensure_repo(group)
+        lock = self._get_repo_lock(group)
+        with lock:
+            ### Check if repo exists
+            repo = self._ensure_repo(group)
 
-        try:
-            from_commit_obj = repo.commit(from_commit)
-            to_commit_obj = repo.commit(to_commit)
-        except Exception as e:
-            raise ValueError(f"Commits not found: {e}") from e
+            try:
+                from_commit_obj = repo.commit(from_commit)
+                to_commit_obj = repo.commit(to_commit)
+            except Exception as e:
+                raise ValueError(f"Commits not found: {e}") from e
 
-        ### Generate unified diff scoped to this device file only.
-        ### Without path scoping, git includes changes from other devices in the same repo.
-        config_file = f"{device_name}.conf"
-        diff_text = repo.git.diff(from_commit, to_commit, "--", config_file)
+            ### Generate unified diff scoped to this device file only.
+            ### Without path scoping, git includes changes from other devices in the same repo.
+            config_file = f"{device_name}.conf"
+            diff_text = repo.git.diff(from_commit, to_commit, "--", config_file)
 
-        ### Calculate statistics
-        added_lines = diff_text.count("\n+") - diff_text.count("\n+++")
-        removed_lines = diff_text.count("\n-") - diff_text.count("\n---")
+            ### Calculate statistics
+            added_lines = diff_text.count("\n+") - diff_text.count("\n+++")
+            removed_lines = diff_text.count("\n-") - diff_text.count("\n---")
 
-        from_date = datetime.fromtimestamp(from_commit_obj.committed_date, tz=timezone.utc)
-        to_date = datetime.fromtimestamp(to_commit_obj.committed_date, tz=timezone.utc)
+            from_date = datetime.fromtimestamp(from_commit_obj.committed_date, tz=timezone.utc)
+            to_date = datetime.fromtimestamp(to_commit_obj.committed_date, tz=timezone.utc)
 
-        return BackupDiff(
-            device_name=device_name,
-            from_commit=from_commit,
-            to_commit=to_commit,
-            from_timestamp=from_date,
-            to_timestamp=to_date,
-            diff_content=diff_text,
-            lines_added=max(0, added_lines),
-            lines_removed=max(0, removed_lines),
-        )
+            return BackupDiff(
+                device_name=device_name,
+                from_commit=from_commit,
+                to_commit=to_commit,
+                from_timestamp=from_date,
+                to_timestamp=to_date,
+                diff_content=diff_text,
+                lines_added=max(0, added_lines),
+                lines_removed=max(0, removed_lines),
+            )
 
     async def get_latest_commit(self, device_name: str) -> dict[str, Any] | None:
         """

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -277,59 +277,31 @@ class GitService:
             message,
         )
 
-    async def get_config_history(
+    def _get_config_history_sync(
         self,
         device_name: str,
         group: str,
         limit: int | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
-        """
-        Get configuration history for a device.
-
-        Args:
-            device_name: Name of the device
-            group: Device group (determines which repo)
-            limit: Maximum number of history entries to return. None returns all entries.
-
-        Returns:
-            List of history entries with commit info, file sizes, and version numbers
-        """
+        """Blocking git history lookup for a device config file."""
         repo = self._ensure_repo(group)
-        commits = []
+        commits: list[dict[str, Any]] = []
         config_file = f"{device_name}.conf"
 
-        for commit in repo.iter_commits():
+        commit_kwargs: dict[str, Any] = {"paths": config_file}
+        if limit is not None:
+            commit_kwargs["max_count"] = limit
+        if offset > 0:
+            commit_kwargs["skip"] = offset
 
-            ### Check if this commit modified the device's config file
-            modified = False
-
-            if commit.parents:
-                ### Not the first commit - check what files were modified
-                for parent in commit.parents:
-                    diffs = parent.diff(commit)
-                    for diff_item in diffs:
-                        ### Check both old path (a_path) and new path (b_path)
-                        if diff_item.a_path == config_file or diff_item.b_path == config_file:
-                            modified = True
-                            break
-                    if modified:
-                        break
-            else:
-                ### First commit - check if file exists in tree
-                for item in commit.tree.traverse():
-                    if item.path == config_file:
-                        modified = True
-                        break
-
-            if not modified:
-                continue
-
+        for commit in repo.iter_commits(**commit_kwargs):
             ### Get file size at this commit
             file_size_bytes = 0
-            for item in commit.tree.traverse():
-                if item.path == config_file:
-                    file_size_bytes = item.size
-                    break
+            try:
+                file_size_bytes = (commit.tree / config_file).size
+            except KeyError:
+                file_size_bytes = 0
 
             commits.append({
                 "hash": commit.hexsha,
@@ -342,12 +314,52 @@ class GitService:
                 "version_number": 0,  # Will be set after we know total count
             })
 
+        total_count = len(commits)
+        try:
+            total_count = int(repo.git.rev_list("--count", "HEAD", "--", config_file).strip())
+        except (ValueError, GitCommandError):
+            total_count = len(commits)
+
         ### Assign version numbers globally - oldest commit = 1, newest = N
         ### Commits are newest first, so reverse the numbering
         for idx, commit in enumerate(commits):
-            commit["version_number"] = len(commits) - idx
+            commit["version_number"] = max(0, total_count - (offset + idx))
 
-        return commits if limit is None else commits[:limit]
+        return commits
+
+    async def get_config_history(
+        self,
+        device_name: str,
+        group: str,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """
+        Get configuration history for a device.
+
+        Args:
+            device_name: Name of the device
+            group: Device group (determines which repo)
+            limit: Maximum number of history entries to return. None returns all entries.
+            offset: Number of most recent entries to skip (for pagination)
+
+        Returns:
+            List of history entries with commit info, file sizes, and version numbers
+        """
+        return await asyncio.to_thread(self._get_config_history_sync, device_name, group, limit, offset)
+
+    def _get_config_history_count_sync(self, device_name: str, group: str) -> int:
+        """Return commit count for a device config file using git rev-list."""
+        repo = self._ensure_repo(group)
+        config_file = f"{device_name}.conf"
+        try:
+            return int(repo.git.rev_list("--count", "HEAD", "--", config_file).strip())
+        except (ValueError, GitCommandError):
+            return 0
+
+    async def get_config_history_count(self, device_name: str, group: str) -> int:
+        """Get configuration history count without loading full history."""
+        return await asyncio.to_thread(self._get_config_history_count_sync, device_name, group)
 
     async def get_config_at_commit(
         self,

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -7,7 +7,7 @@ commits, history retrieval, and diff generation.
 import asyncio
 import logging
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -360,6 +360,67 @@ class GitService:
     async def get_config_history_count(self, device_name: str, group: str) -> int:
         """Get configuration history count without loading full history."""
         return await asyncio.to_thread(self._get_config_history_count_sync, device_name, group)
+
+    def _get_backup_graph_counts_sync(
+        self,
+        device_name: str,
+        group: str,
+        days: int = 365,
+        tz_offset_minutes: int = 0,
+    ) -> list[dict[str, int | str]]:
+        """Return per-day backup counts for the last N days (local dates)."""
+        bounded_days = max(1, int(days))
+        offset_delta = timedelta(minutes=-int(tz_offset_minutes))
+
+        lock = self._get_repo_lock(group)
+        with lock:
+            repo = self._ensure_repo(group)
+            if not self._has_commits(repo):
+                return []
+            
+            config_file = f"{device_name}.conf"
+
+            ### Calculate cutoff datetime in UTC based on local date boundary
+            now_utc = datetime.now(timezone.utc)
+            today_local = (now_utc + offset_delta).date()
+            start_date = today_local - timedelta(days=bounded_days - 1)
+            start_dt_utc = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc) - offset_delta
+
+            ### Try to get commit counts per day via git
+            counts: dict[str, int] = {}
+            try:
+                for commit in repo.iter_commits(paths=config_file, since=start_dt_utc.isoformat()):
+                    commit_dt = datetime.fromtimestamp(commit.committed_date, tz=timezone.utc)
+                    local_dt = commit_dt + offset_delta
+                    if local_dt.date() < start_date:
+                        continue
+
+                    ### Count commits when local date is within the last N days
+                    date_key = local_dt.date().isoformat()
+                    counts[date_key] = counts.get(date_key, 0) + 1
+            except Exception:
+                return []
+
+            return [
+                {"date": date_key, "count": counts[date_key]}
+                for date_key in sorted(counts.keys())
+            ]
+
+    async def get_backup_graph_counts(
+        self,
+        device_name: str,
+        group: str,
+        days: int = 365,
+        tz_offset_minutes: int = 0,
+    ) -> list[dict[str, int | str]]:
+        """Get per-day backup counts for the last N days without full history."""
+        return await asyncio.to_thread(
+            self._get_backup_graph_counts_sync,
+            device_name,
+            group,
+            days,
+            tz_offset_minutes,
+        )
 
     async def get_config_at_commit(
         self,

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -42,6 +42,8 @@ READ_CHUNK_SIZE = 4096
 READ_POLL_INTERVAL_SECONDS = 1.0
 LARGE_OUTPUT_TIMEOUT_THRESHOLD_BYTES = 256 * 1024
 LARGE_OUTPUT_INACTIVITY_TIMEOUT_SECONDS = 90
+PROMPT_CONFIRM_IDLE_SECONDS = 0.2
+PROMPT_CONFIRM_MAX_SECONDS = 2.0
 
 PaginationRule = tuple[re.Pattern[str], str]
 
@@ -311,19 +313,23 @@ class SSHService:
                     tail_lines.pop()
 
                 if tail_lines and self._line_matches_prompt(tail_lines[-1], patterns):
-                    ### Collect any trailing bytes that arrive immediately after prompt detection
-                    ### This reduces output bleed into the next command on some devices
-                    idle_timeout = 0.05
-                    max_chunks = 16
+                    ### Confirm prompt by waiting for a short idle window
+                    ### If more output arrives, treat it as a false prompt match and keep reading
+                    idle_timeout = PROMPT_CONFIRM_IDLE_SECONDS
+                    max_total_seconds = PROMPT_CONFIRM_MAX_SECONDS
                     if len(buffer) >= LARGE_OUTPUT_TIMEOUT_THRESHOLD_BYTES:
                         ### Allow a longer quiet window to catch late chunks from large outputs
-                        idle_timeout = 0.2
-                        max_chunks = 64
-                    buffer += await self._read_trailing_output(
+                        idle_timeout = max(idle_timeout, 0.4)
+                        max_total_seconds = max(max_total_seconds, 4.0)
+                    trailing = await self._read_trailing_output(
                         stream,
                         idle_timeout=idle_timeout,
-                        max_chunks=max_chunks,
+                        max_chunks=None,
+                        max_total_seconds=max_total_seconds,
                     )
+                    if trailing:
+                        buffer += trailing
+                        continue
                     return buffer
 
                 ### Handle pagination prompts by sending the response for the matching pagination rule
@@ -402,11 +408,19 @@ class SSHService:
     async def _read_trailing_output(
         stream: asyncssh.SSHReader,
         idle_timeout: float = 0.05,
-        max_chunks: int = 16,
+        max_chunks: int | None = 16,
+        max_total_seconds: float | None = None,
     ) -> str:
         """Read immediately available trailing output after prompt detection."""
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
         trailing = ""
-        for _ in range(max_chunks):
+        chunks_read = 0
+        while True:
+            if max_chunks is not None and chunks_read >= max_chunks:
+                break
+            if max_total_seconds is not None and (loop.time() - start_time) >= max_total_seconds:
+                break
             try:
                 chunk = await asyncio.wait_for(stream.read(READ_CHUNK_SIZE), timeout=idle_timeout)
             except asyncio.TimeoutError:
@@ -416,6 +430,7 @@ class SSHService:
                 break
 
             trailing += chunk
+            chunks_read += 1
 
         return trailing
 

--- a/backend/app/services/telnet_service.py
+++ b/backend/app/services/telnet_service.py
@@ -20,6 +20,8 @@ from app.services.ssh_service import (
     GENERIC_PROMPT_PATTERNS,
     LARGE_OUTPUT_INACTIVITY_TIMEOUT_SECONDS,
     LARGE_OUTPUT_TIMEOUT_THRESHOLD_BYTES,
+    PROMPT_CONFIRM_IDLE_SECONDS,
+    PROMPT_CONFIRM_MAX_SECONDS,
     READ_CHUNK_SIZE,
     READ_POLL_INTERVAL_SECONDS,
 )
@@ -360,20 +362,23 @@ class TelnetService:
                     tail_lines.pop()
 
                 if tail_lines and self._line_matches_prompt(tail_lines[-1], patterns):
-                    ### Collect any trailing bytes that arrive immediately after prompt detection
-                    ### This reduces output bleed into the next command on some devices
-
-                    idle_timeout = 0.05
-                    max_chunks = 16
+                    ### Confirm prompt by waiting for a short idle window
+                    ### If more output arrives, treat it as a false prompt match and keep reading
+                    idle_timeout = PROMPT_CONFIRM_IDLE_SECONDS
+                    max_total_seconds = PROMPT_CONFIRM_MAX_SECONDS
                     if len(buffer) >= LARGE_OUTPUT_TIMEOUT_THRESHOLD_BYTES:
                         # Allow a longer quiet window to catch late chunks from large outputs.
-                        idle_timeout = 0.2
-                        max_chunks = 64
-                    buffer += await self._read_trailing_output(
+                        idle_timeout = max(idle_timeout, 0.4)
+                        max_total_seconds = max(max_total_seconds, 4.0)
+                    trailing = await self._read_trailing_output(
                         reader,
                         idle_timeout=idle_timeout,
-                        max_chunks=max_chunks,
+                        max_chunks=None,
+                        max_total_seconds=max_total_seconds,
                     )
+                    if trailing:
+                        buffer += trailing
+                        continue
                     return buffer
 
                 ### Handle pagination prompts by sending the response for the matching pagination rule
@@ -452,11 +457,19 @@ class TelnetService:
     async def _read_trailing_output(
         reader: Any,
         idle_timeout: float = 0.05,
-        max_chunks: int = 16,
+        max_chunks: int | None = 16,
+        max_total_seconds: float | None = None,
     ) -> str:
         """Read immediately available trailing output after prompt detection."""
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
         trailing = ""
-        for _ in range(max_chunks):
+        chunks_read = 0
+        while True:
+            if max_chunks is not None and chunks_read >= max_chunks:
+                break
+            if max_total_seconds is not None and (loop.time() - start_time) >= max_total_seconds:
+                break
             try:
                 chunk = await asyncio.wait_for(reader.read(READ_CHUNK_SIZE), timeout=idle_timeout)
             except asyncio.TimeoutError:
@@ -466,6 +479,7 @@ class TelnetService:
                 break
 
             trailing += chunk
+            chunks_read += 1
 
         return trailing
 

--- a/backend/config/vendors/OS_TYPES.md
+++ b/backend/config/vendors/OS_TYPES.md
@@ -11,6 +11,7 @@
 | Cisco        | ACS                   | [cisco_acs.yaml](/backend/config/vendors/cisco_acs.yaml)                         |                                        |
 | Cisco        | AireOS                | [cisco_aireos.yaml](/backend/config/vendors/cisco_aireos.yaml)                   | [AireOS](#cisco-aireos)                |
 | Cisco        | IOS                   | [cisco_ios.yaml](/backend/config/vendors/cisco_ios.yaml)                         |                                        |
+| Cisco        | IOS-XR                | [cisco_iosxr.yaml](/backend/config/vendors/cisco_iosxr.yaml)                     |                                        |
 | Cisco        | NXOS                  | [cisco_nxos.yaml](/backend/config/vendors/cisco_nxos.yaml)                       |                                        |
 | Cisco        | ASA                   | [cisco_asa.yaml](/backend/config/vendors/cisco_asa.yaml)                         |                                        |
 | Citrix       | NetScaler             | [citrix_netscaler.yaml](/backend/config/vendors/citrix_netscaler.yaml)           |                                        |

--- a/backend/config/vendors/OS_TYPES.md
+++ b/backend/config/vendors/OS_TYPES.md
@@ -15,6 +15,7 @@
 | Cisco        | NXOS                  | [cisco_nxos.yaml](/backend/config/vendors/cisco_nxos.yaml)                       |                                        |
 | Cisco        | ASA                   | [cisco_asa.yaml](/backend/config/vendors/cisco_asa.yaml)                         |                                        |
 | Citrix       | NetScaler             | [citrix_netscaler.yaml](/backend/config/vendors/citrix_netscaler.yaml)           |                                        |
+| Eltex        | Eltex                 | [eltex_eltex.yaml](/backend/config/vendors/eltex_eltex.yaml)                     |                                        |
 | Fortinet     | FortiGate             | [fortinet_fortigate.yaml](/backend/config/vendors/fortinet_fortigate.yaml)       | [FortiGate](#fortinet-device-types)    |
 | Fortinet     | FortiOS               | [fortinet_fortios.yaml](/backend/config/vendors/fortinet_fortios.yaml)           | [FortiOS](#fortinet-device-types)      |
 | HP           | ProCurve              | [hp_procurve.yaml](/backend/config/vendors/hp_procurve.yaml)                     |                                        |

--- a/backend/config/vendors/a10_acos.yaml
+++ b/backend/config/vendors/a10_acos.yaml
@@ -73,3 +73,10 @@ processing:
         replacement: 'secret encrypted <hidden>'
       - search: 'password encrypted (\S+)'
         replacement: 'password encrypted <hidden>'
+      - search: 'pass-phrase encrypted (\S+)'
+        replacement: 'pass-phrase encrypted <hidden>'
+      - search: 'md5 encrypted (\S+)'
+        replacement: 'md5 encrypted <hidden>'
+      ### Global encrypted pattern
+      - search: 'encrypted (\S+)'
+        replacement: 'encrypted <hidden>'

--- a/backend/config/vendors/a10_acos.yaml
+++ b/backend/config/vendors/a10_acos.yaml
@@ -66,18 +66,10 @@ processing:
   ### Secret masking. When enabled=false, no redaction is applied.
   redaction:
     enabled: false
-    # patterns:
-    #   - search: "^(snmp-server community).*$"
-    #     replacement: "\\1<secret redacted>"
-    #   - search: "^(snmp-server user (\\S+) (\\S+) auth (\\S+)) (\\S+) (priv) (\\S+).*$"
-    #     replacement: "\\1<secret redacted>"
-    #   - search: "^(snmp-server host.*? )\\S+( udp-port \\d+)?$"
-    #     replacement: "\\1<secret redacted>"
-    #   - search: "^(snmp-server mib community-map) \\S+ ?(.*)$"
-    #     replacement: "\\1<secret redacted>"
-    #   - search: "^(password \\d+) (\\S+)$"
-    #     replacement: "\\1<secret redacted>"
-    #   - search: "^(radius-server .*key(?: \\d+)?) \\S+$"
-    #     replacement: "\\1<secret redacted>"
-    #   - search: "^(tacacs-server .*key(?: \\d+)?) \\S+$"
-    #     replacement: "\\1<secret redacted>"
+    patterns:
+      - search: 'community read encrypted (\S+)'
+        replacement: 'community read encrypted <hidden>'
+      - search: 'secret encrypted (\S+)'
+        replacement: 'secret encrypted <hidden>'
+      - search: 'password encrypted (\S+)'
+        replacement: 'password encrypted <hidden>'

--- a/backend/config/vendors/cisco_iosxr.yaml
+++ b/backend/config/vendors/cisco_iosxr.yaml
@@ -1,0 +1,74 @@
+### Cisco IOS XR Vendor Configuration
+## Instructions for backing up Cisco IOS XR devices
+
+vendor:
+  id: "cisco_iosxr"
+  name: "Cisco IOS XR"
+  description: "Cisco IOS XR devices"
+
+### Session-level behavior
+session:
+  comment_prefix: "! "
+  prompt: '^(\r?[\w.@:\/-]+[#>]\s?)$$'
+
+### Commands to execute for backup
+## Supported step types in command phases:
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
+commands:
+  ### Pre-backup commands (prepare the session) (OPTIONAL)
+  ## Command outputs aren't saved in stored configuration
+  pre_backup:
+    - command: "terminal length 0"
+    - command: "terminal width 0"
+    - command: "terminal exec prompt no-timestamp"
+
+  ### Main backup command(s)
+  ## Commands whose output becomes the stored configuration
+  backup:
+    - command: "show inventory all"
+      description: "Collect inventory as metadata"
+      metadata: true
+    - command: "show version"
+      description: "Collect platform as metadata"
+      metadata: true
+    - command: "show platform"
+      description: "Collect platform information as metadata"
+      metadata: true
+    - command: "show running-config"
+      description: "Get running configuration"
+
+  ### Post-backup commands (cleanup) (OPTIONAL)
+  ## Command outputs aren't saved in stored configuration
+  post_backup:
+    - command: "exit"
+
+### Configuration processing rules
+## Processing reduces diff noise and trims non-config boilerplate
+processing:
+  ### Lines to strip from captured config (regex patterns)
+  strip_patterns:
+    - "^% Invalid input detected at '\\^' marker\\.$"
+    - "^\\s+\\^$"
+    - "^Building configuration\\.\\.\\."
+    - "^Current configuration\\s*:\\s*\\d+\\s*bytes"
+    - "^!\\s*Last configuration change"
+    - "^!\\s*NVRAM config last updated"
+    - "^ntp clock-period \\d+"
+    - '^ (tunnel mpls traffic-eng bandwidth [^\n]*)\n((?: [^\n]*\n)* tunnel mpls traffic-eng auto-bw)'
+    - 'Time source is.*'
+    - 'Load for.*'
+
+  ### Lines that mark config boundaries
+  ## If either boundary is missing, keep from/to the file edge.
+  # config_start: "^version \\d+\\.\\d+"
+  # config_end: "^end$"
+
+  ### Secret masking. When enabled=false, no redaction is applied.
+  redaction:
+    enabled: false
+    patterns:
+      - search: "^(snmp-server community).*"
+        replacement: "\\1 <configuration removed>"
+      - search: 'secret (\d+) (\S+).*'
+        replacement: "<secret hidden>"

--- a/backend/config/vendors/eltex_eltex.yaml
+++ b/backend/config/vendors/eltex_eltex.yaml
@@ -1,0 +1,76 @@
+### Eltex Vendor Configuration
+## Instructions for backing up Eltex devices
+
+vendor:
+  id: "eltex_eltex"
+  name: "Eltex"
+  description: "Tested with MES2324FB Version: 4.0.7.1 Build: 37 (master)"
+
+### Session-level behavior
+session:
+  comment_prefix: "! "
+  prompt: '^\s?[\w.@()-]+[#>]\s?$'
+
+### Commands to execute for backup
+## Supported step types in command phases:
+## - command: sends command text
+## - command + then: sends command text, then sends interactive input
+commands:
+  ### Pre-backup commands (prepare the session) (OPTIONAL)
+  ## Command outputs aren't saved in stored configuration
+  pre_backup:
+    - command: "terminal datadump"
+    - command: "set cli pagination off"
+
+  ### Main backup command(s)
+  ## Commands whose output becomes the stored configuration
+  backup:
+    - command: "show version"
+      description: "Collect platform as metadata"
+      metadata: true
+    - command: "show inventory"
+      description: "Collect inventory as metadata"
+      metadata: true
+    - command: "show running-config"
+      description: "Get running configuration"
+
+  ### Post-backup commands (cleanup) (OPTIONAL)
+  ## Command outputs aren't saved in stored configuration
+  post_backup:
+    - command: "disable"
+    - command: "exit"
+
+### Configuration processing rules
+## Processing reduces diff noise and trims non-config boilerplate
+processing:
+  ### Lines to strip from captured config (regex patterns)
+  strip_patterns:
+    - '^% Invalid input detected at "\^" marker\.$|^\s+\^$'
+
+  ### Lines that mark config boundaries
+  ## If either boundary is missing, keep from/to the file edge.
+  # config_start: "^version \\d+\\.\\d+"
+  # config_end: "^end$"
+
+  ### Secret masking. When enabled=false, no redaction is applied.
+  redaction:
+    enabled: false
+    patterns:
+      - search: '^(snmp-server community).*'
+        replacement: "\\1 <configuration removed>"
+      - search: '^(enable (password|secret)( level \d+)? \d) .+'
+        replacement: "\\1 <secret hidden>"
+      - search: '^(\s+(?:password|secret)) (?:\d )?\S+'
+        replacement: "\\1 <secret hidden>"
+      - search: '^(tacacs-server (.+ )?key) .+'
+        replacement: "\\1 <secret hidden>"
+      - search: '^((tacacs|radius) server [^\n]+\n( +[^\n]+\n)*\s+key) [^\n]+$'
+        replacement: "\\1 <secret hidden>"
+      - search: 'username (\S+) privilege (\d+) (\S+).*'
+        replacement: "<secret hidden>"
+      - search: '^username \S+ password \d \S+'
+        replacement: "<secret hidden>"
+      - search: '^enable password \d \S+'
+        replacement: "<secret hidden>"
+      - search: 'wpa-psk ascii \d \S+'
+        replacement: "<secret hidden>"

--- a/frontend/src/api/backups.ts
+++ b/frontend/src/api/backups.ts
@@ -4,6 +4,7 @@ import type {
   BackupJobStatus,
   BackupJobsResponse,
   BackupHistoryResponse,
+  BackupGraphResponse,
 } from "../types/backup"
 
 export const backupApi = {
@@ -44,6 +45,18 @@ export const backupApi = {
     if (limit !== undefined) params.limit = limit
     if (offset !== undefined) params.offset = offset
     const response = await api.get<BackupHistoryResponse>(`/backups/history/${deviceName}`, { params })
+    return response.data
+  },
+
+  async getHistoryGraph(
+    deviceName: string,
+    days?: number,
+    tzOffsetMinutes?: number,
+  ): Promise<BackupGraphResponse> {
+    const params: Record<string, number> = {}
+    if (days !== undefined) params.days = days
+    if (tzOffsetMinutes !== undefined) params.tz_offset_minutes = tzOffsetMinutes
+    const response = await api.get<BackupGraphResponse>(`/backups/history/graph/${deviceName}`, { params })
     return response.data
   },
 

--- a/frontend/src/api/backups.ts
+++ b/frontend/src/api/backups.ts
@@ -1,5 +1,10 @@
 import api from "./index"
-import type { BackupTriggerResponse, BackupJobStatus, BackupJobsResponse } from "../types/backup"
+import type {
+  BackupTriggerResponse,
+  BackupJobStatus,
+  BackupJobsResponse,
+  BackupHistoryResponse,
+} from "../types/backup"
 
 export const backupApi = {
   async triggerAll(params?: Record<string, string>): Promise<BackupTriggerResponse> {
@@ -34,9 +39,11 @@ export const backupApi = {
     return response.data
   },
 
-  async getHistory(deviceName: string, limit?: number): Promise<Record<string, unknown>> {
-    const params = limit === undefined ? undefined : { limit }
-    const response = await api.get(`/backups/history/${deviceName}`, { params })
+  async getHistory(deviceName: string, limit?: number, offset?: number): Promise<BackupHistoryResponse> {
+    const params: Record<string, number> = {}
+    if (limit !== undefined) params.limit = limit
+    if (offset !== undefined) params.offset = offset
+    const response = await api.get<BackupHistoryResponse>(`/backups/history/${deviceName}`, { params })
     return response.data
   },
 

--- a/frontend/src/components/BackupContributionGraph.vue
+++ b/frontend/src/components/BackupContributionGraph.vue
@@ -7,8 +7,14 @@ interface BackupEntry {
   [key: string]: unknown
 }
 
+interface BackupDayCount {
+  date: string
+  count: number
+}
+
 interface Props {
-  backups: BackupEntry[]
+  backups?: BackupEntry[]
+  dailyCounts?: BackupDayCount[]
   selectedDate?: string
 }
 
@@ -39,7 +45,15 @@ function formatLocalDate(date: Date): string {
 const backupsByDate = computed((): Map<string, number> => {
   const map = new Map<string, number>()
 
-  for (const backup of props.backups) {
+  if (props.dailyCounts && props.dailyCounts.length > 0) {
+    for (const day of props.dailyCounts) {
+      if (!day.date) continue
+      map.set(day.date, (map.get(day.date) || 0) + day.count)
+    }
+    return map
+  }
+
+  for (const backup of props.backups || []) {
     // Parse ISO timestamp and convert to local date
     const date = new Date(backup.timestamp)
     // Get local date string (not UTC)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,8 +7,8 @@ import router from "./router"
 import "./style.css"
 
 // Versions
-export const APP_VERSION = "2.2.1" // KiwiSSH backend + frontend bundled together
-export const FRONTEND_VERSION = "1.3.1" // Frontend version only
+export const APP_VERSION = "2.3.0" // KiwiSSH backend + frontend bundled together
+export const FRONTEND_VERSION = "1.4.0" // Frontend version only
 
 function applyInitialTheme(): void {
 	const themeStorageKey = "kiwissh-theme"

--- a/frontend/src/types/backup.ts
+++ b/frontend/src/types/backup.ts
@@ -82,6 +82,22 @@ export interface BackupHistoryResponse {
   error?: string
 }
 
+export interface BackupGraphDay {
+  date: string
+  count: number
+}
+
+export interface BackupGraphResponse {
+  device_name: string
+  days: number
+  tz_offset_minutes?: number
+  from?: string
+  to?: string
+  total?: number
+  counts: BackupGraphDay[]
+  error?: string
+}
+
 export interface BackupJobsResponse {
   count: number
   total_count: number

--- a/frontend/src/types/backup.ts
+++ b/frontend/src/types/backup.ts
@@ -61,6 +61,27 @@ export interface BackupJobRecord {
   metadata_output?: string | null
 }
 
+export interface BackupHistoryEntry {
+  hash: string
+  short_hash: string
+  message: string
+  author: string
+  date: string
+  timestamp: string
+  file_size_bytes: number
+  version_number: number
+}
+
+export interface BackupHistoryResponse {
+  device_name: string
+  history: BackupHistoryEntry[]
+  count: number
+  total_count: number
+  limit: number | null
+  offset: number
+  error?: string
+}
+
 export interface BackupJobsResponse {
   count: number
   total_count: number

--- a/frontend/src/views/DeviceDetailView.vue
+++ b/frontend/src/views/DeviceDetailView.vue
@@ -20,7 +20,8 @@ interface BackupEntry {
   version_number: number
 }
 
-const graphHistoryCache = new Map<string, Array<{ timestamp: string }>>()
+const graphHistoryCache = new Map<string, Array<{ date: string; count: number }>>()
+const graphDays = 365
 
 const route = useRoute()
 const router = useRouter()
@@ -47,7 +48,7 @@ const backupHistory = ref<BackupEntry[]>([])
 const historyLoading = ref(false)
 const historyError = ref<string | null>(null)
 const totalHistoryCount = ref(0)
-const graphBackups = ref<Array<{ timestamp: string }>>([])
+const graphDailyCounts = ref<Array<{ date: string; count: number }>>([])
 
 // Filter states
 const filterDateFrom = ref<string>("")
@@ -90,7 +91,7 @@ onMounted(async () => {
   currentPage.value = 1
   const devicePromise = devicesStore.fetchDevice(deviceName.value)
   const historyPromise = loadBackupHistory()
-  const graphPromise = loadGraphHistory() // WIP
+  const graphPromise = loadGraphHistory()
   const vendorPromise = devicesStore.vendors.length === 0
     ? devicesStore.fetchVendors()
     : Promise.resolve()
@@ -98,20 +99,21 @@ onMounted(async () => {
 })
 
 async function loadGraphHistory() {
-  const cacheKey = deviceName.value
+  const tzOffsetMinutes = new Date().getTimezoneOffset()
+  const cacheKey = `${deviceName.value}|${graphDays}|${tzOffsetMinutes}`
   const cached = graphHistoryCache.get(cacheKey)
   if (cached) {
-    graphBackups.value = cached
+    graphDailyCounts.value = cached
     return
   }
 
   try {
-    const response = await backupApi.getHistory(deviceName.value)
-    const timestamps = (response.history || []).map((entry) => ({ timestamp: entry.timestamp }))
-    graphHistoryCache.set(cacheKey, timestamps)
-    graphBackups.value = timestamps
+    const response = await backupApi.getHistoryGraph(deviceName.value, graphDays, tzOffsetMinutes)
+    const counts = response.counts || []
+    graphHistoryCache.set(cacheKey, counts)
+    graphDailyCounts.value = counts
   } catch (e) {
-    graphBackups.value = []
+    graphDailyCounts.value = []
   }
 }
 
@@ -285,7 +287,8 @@ async function triggerBackup() {
 
     // Reload history after backup (for UI update)
     await loadBackupHistory()
-    graphHistoryCache.delete(deviceName.value)
+    const tzOffsetMinutes = new Date().getTimezoneOffset()
+    graphHistoryCache.delete(`${deviceName.value}|${graphDays}|${tzOffsetMinutes}`)
     await loadGraphHistory()
 
     // Reload device data from API to get updated status from database
@@ -561,7 +564,7 @@ function formatFileSize(bytes: number): string {
       </div>
 
       <BackupContributionGraph
-        :backups="graphBackups"
+        :daily-counts="graphDailyCounts"
         :selected-date="selectedDateInGraph"
         @day-selected="setSelectedGraphDate"
         @day-cleared="clearSelectedGraphDate"

--- a/frontend/src/views/DeviceDetailView.vue
+++ b/frontend/src/views/DeviceDetailView.vue
@@ -44,6 +44,7 @@ const devicePort = computed(() => {
 const backupHistory = ref<BackupEntry[]>([])
 const historyLoading = ref(false)
 const historyError = ref<string | null>(null)
+const totalHistoryCount = ref(0)
 
 // Filter states
 const filterDateFrom = ref<string>("")
@@ -83,11 +84,14 @@ const latestBackup = computed<BackupEntry | null>(() => {
 })
 
 onMounted(async () => {
-  await devicesStore.fetchDevice(deviceName.value)
-  if (devicesStore.vendors.length === 0) {
-    await devicesStore.fetchVendors()
-  }
-  await loadBackupHistory()
+  currentPage.value = 1
+  const devicePromise = devicesStore.fetchDevice(deviceName.value)
+  const historyPromise = loadBackupHistory()
+  const graphPromise = loadGraphHistory() // WIP
+  const vendorPromise = devicesStore.vendors.length === 0
+    ? devicesStore.fetchVendors()
+    : Promise.resolve()
+  await Promise.all([devicePromise, vendorPromise, historyPromise, graphPromise])
 })
 
 async function loadBackupHistory() {
@@ -95,8 +99,11 @@ async function loadBackupHistory() {
   historyError.value = null
 
   try {
-    const response = await backupApi.getHistory(deviceName.value)
+    const limit = pageSize.value
+    const offset = (currentPage.value - 1) * pageSize.value
+    const response = await backupApi.getHistory(deviceName.value, limit, offset)
     backupHistory.value = response.history || []
+    totalHistoryCount.value = response.total_count ?? response.count ?? backupHistory.value.length
 
     // Auto-select the two most recent valid commits for diff
     if (commitOptions.value.length >= 2) {
@@ -111,6 +118,7 @@ async function loadBackupHistory() {
     }
   } catch (e) {
     historyError.value = e instanceof Error ? e.message : "Failed to load backup history"
+    totalHistoryCount.value = 0
   } finally {
     historyLoading.value = false
   }
@@ -156,13 +164,9 @@ const commitOptions = computed((): BackupEntry[] => {
 })
 
 // Pagination computed properties
-const totalPages = computed(() => Math.ceil(filteredBackupHistory.value.length / pageSize.value))
+const totalPages = computed(() => Math.max(1, Math.ceil(totalHistoryCount.value / pageSize.value)))
 
-const paginatedBackupHistory = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  const end = start + pageSize.value
-  return filteredBackupHistory.value.slice(start, end)
-})
+const paginatedBackupHistory = computed(() => filteredBackupHistory.value)
 
 function clearFilters() {
   filterDateFrom.value = ""
@@ -182,6 +186,7 @@ function clearSelectedGraphDate() {
 
 function handlePageSizeChange() {
   currentPage.value = 1 // Reset to first page when page size changes
+  void loadBackupHistory()
 }
 
 function scrollToTop() {
@@ -193,12 +198,14 @@ function goToPreviousHistoryPage() {
   if (currentPage.value <= 1) return
   currentPage.value -= 1
   scrollToTop()
+  void loadBackupHistory()
 }
 
 function goToNextHistoryPage() {
   if (currentPage.value >= totalPages.value) return
   currentPage.value += 1
   scrollToTop()
+  void loadBackupHistory()
 }
 
 async function loadDiff() {

--- a/frontend/src/views/DeviceDetailView.vue
+++ b/frontend/src/views/DeviceDetailView.vue
@@ -62,7 +62,25 @@ const diffStats = ref({ added: 0, removed: 0 })
 const diffLoading = ref(false)
 const diffError = ref<string | null>(null)
 const downloadingBackups = ref<Record<string, boolean>>({})
+const downloadingLatest = ref(false)
 const jobLookupLoading = ref<Record<string, boolean>>({})
+
+const latestBackup = computed<BackupEntry | null>(() => {
+  let latest: BackupEntry | null = null
+  for (const entry of backupHistory.value) {
+    const entryTime = new Date(entry.timestamp).getTime()
+    if (!Number.isFinite(entryTime)) continue
+    if (!latest) {
+      latest = entry
+      continue
+    }
+    const latestTime = new Date(latest.timestamp).getTime()
+    if (!Number.isFinite(latestTime) || entryTime > latestTime) {
+      latest = entry
+    }
+  }
+  return latest
+})
 
 onMounted(async () => {
   await devicesStore.fetchDevice(deviceName.value)
@@ -343,6 +361,40 @@ async function downloadConfig(backup: BackupEntry) {
   }
 }
 
+async function downloadLatestConfig() {
+  if (downloadingLatest.value) {
+    return
+  }
+
+  downloadingLatest.value = true
+
+  try {
+    const response = await backupApi.getLatestConfig(deviceName.value)
+    const config = response.config || ""
+    if (!config) {
+      alert("No backup config found for this device.")
+      return
+    }
+
+    const versionNumber = response.version_number ?? latestBackup.value?.version_number
+    const versionLabel = versionNumber ? `v${versionNumber}` : "latest"
+
+    const blob = new Blob([config], { type: "text/plain" })
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `${deviceName.value}-${versionLabel}.conf`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+  } catch (e) {
+    alert(`Download failed: ${e instanceof Error ? e.message : "Unknown error"}`)
+  } finally {
+    downloadingLatest.value = false
+  }
+}
+
 function isDownloading(backupHash: string): boolean {
   return Boolean(downloadingBackups.value[backupHash])
 }
@@ -398,6 +450,50 @@ function formatFileSize(bytes: number): string {
               :class="isFavorite ? 'bg-amber-100 text-amber-700 border-amber-200 hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-300 dark:border-amber-700 dark:hover:bg-amber-900/60' : 'bg-gray-100 text-gray-600 border-gray-200 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600'"
             >
               {{ isFavorite ? "★ Favorited" : "☆ Favorite" }}
+            </button>
+            <button
+              @click="downloadLatestConfig"
+              :disabled="!latestBackup || downloadingLatest"
+              class="btn btn-secondary"
+              :title="latestBackup ? 'Download latest config' : 'No backups available'"
+            >
+              <svg
+                v-if="downloadingLatest"
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-4 w-4 inline mr-1 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              <svg
+                v-else
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-4 w-4 inline mr-1"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                />
+              </svg>
+              {{ downloadingLatest ? "Downloading..." : "Download Latest" }}
             </button>
             <button @click="triggerBackup" class="btn btn-primary">
               Trigger Backup
@@ -543,7 +639,7 @@ function formatFileSize(bytes: number): string {
                   </p>
                 </div>
                 <button
-                  @click="downloadConfig(backup)"
+                  @click.stop="downloadConfig(backup)"
                   :disabled="isDownloading(backup.hash)"
                   class="shrink-0 btn btn-secondary py-1 px-3 text-sm whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
                 >

--- a/frontend/src/views/DeviceDetailView.vue
+++ b/frontend/src/views/DeviceDetailView.vue
@@ -20,6 +20,8 @@ interface BackupEntry {
   version_number: number
 }
 
+const graphHistoryCache = new Map<string, Array<{ timestamp: string }>>()
+
 const route = useRoute()
 const router = useRouter()
 const devicesStore = useDevicesStore()
@@ -45,6 +47,7 @@ const backupHistory = ref<BackupEntry[]>([])
 const historyLoading = ref(false)
 const historyError = ref<string | null>(null)
 const totalHistoryCount = ref(0)
+const graphBackups = ref<Array<{ timestamp: string }>>([])
 
 // Filter states
 const filterDateFrom = ref<string>("")
@@ -93,6 +96,24 @@ onMounted(async () => {
     : Promise.resolve()
   await Promise.all([devicePromise, vendorPromise, historyPromise, graphPromise])
 })
+
+async function loadGraphHistory() {
+  const cacheKey = deviceName.value
+  const cached = graphHistoryCache.get(cacheKey)
+  if (cached) {
+    graphBackups.value = cached
+    return
+  }
+
+  try {
+    const response = await backupApi.getHistory(deviceName.value)
+    const timestamps = (response.history || []).map((entry) => ({ timestamp: entry.timestamp }))
+    graphHistoryCache.set(cacheKey, timestamps)
+    graphBackups.value = timestamps
+  } catch (e) {
+    graphBackups.value = []
+  }
+}
 
 async function loadBackupHistory() {
   historyLoading.value = true
@@ -264,6 +285,8 @@ async function triggerBackup() {
 
     // Reload history after backup (for UI update)
     await loadBackupHistory()
+    graphHistoryCache.delete(deviceName.value)
+    await loadGraphHistory()
 
     // Reload device data from API to get updated status from database
     await devicesStore.fetchDevice(deviceName.value)
@@ -538,7 +561,7 @@ function formatFileSize(bytes: number): string {
       </div>
 
       <BackupContributionGraph
-        :backups="backupHistory"
+        :backups="graphBackups"
         :selected-date="selectedDateInGraph"
         @day-selected="setSelectedGraphDate"
         @day-cleared="clearSelectedGraphDate"

--- a/frontend/src/views/DeviceDetailView.vue
+++ b/frontend/src/views/DeviceDetailView.vue
@@ -62,6 +62,7 @@ const diffStats = ref({ added: 0, removed: 0 })
 const diffLoading = ref(false)
 const diffError = ref<string | null>(null)
 const downloadingBackups = ref<Record<string, boolean>>({})
+const jobLookupLoading = ref<Record<string, boolean>>({})
 
 onMounted(async () => {
   await devicesStore.fetchDevice(deviceName.value)
@@ -255,6 +256,61 @@ async function triggerBackup() {
       }
     }
     alert(`Backup failed: ${e instanceof Error ? e.message : "Unknown error"}`)
+  }
+}
+
+async function openJobLog(backup: BackupEntry) {
+  if (!backup.timestamp) {
+    alert("Unable to locate job log: backup timestamp is missing.")
+    return
+  }
+
+  if (jobLookupLoading.value[backup.hash]) {
+    return
+  }
+
+  jobLookupLoading.value[backup.hash] = true
+
+  try {
+    const response = await backupApi.getJobs(deviceName.value, "success", 5000, 0)
+    const jobs = Array.isArray(response.jobs) ? response.jobs : []
+    const commitTime = new Date(backup.timestamp).getTime()
+
+    if (!Number.isFinite(commitTime)) {
+      alert("Unable to locate job log: backup timestamp is invalid.")
+      return
+    }
+
+    let bestJob = null as typeof jobs[number] | null
+    let bestDiff = Number.POSITIVE_INFINITY
+    for (const job of jobs) {
+      const jobTime = new Date(job.timestamp).getTime()
+      if (!Number.isFinite(jobTime)) continue
+      const diff = Math.abs(jobTime - commitTime)
+      if (diff < bestDiff) {
+        bestDiff = diff
+        bestJob = job
+      }
+    }
+
+    const maxDiffMs = 15 * 60 * 1000
+    if (!bestJob || bestDiff > maxDiffMs) {
+      alert("Unable to locate matching job log for this backup.")
+      return
+    }
+
+    await router.push({
+      name: "jobs",
+      query: {
+        job_id: bestJob.job_id,
+        device: deviceName.value,
+        open: "1",
+      },
+    })
+  } catch (e) {
+    alert(`Failed to open job log: ${e instanceof Error ? e.message : "Unknown error"}`)
+  } finally {
+    delete jobLookupLoading.value[backup.hash]
   }
 }
 
@@ -466,7 +522,9 @@ function formatFileSize(bytes: number): string {
             <div
               v-for="backup in paginatedBackupHistory"
               :key="backup.hash"
-              class="p-3 hover:bg-gray-50 dark:hover:bg-gray-800/70 transition-colors"
+              class="p-3 hover:bg-gray-50 dark:hover:bg-gray-800/70 transition-colors cursor-pointer"
+              title="Open backup job log"
+              @click="openJobLog(backup)"
             >
               <div class="flex items-center justify-between gap-4">
                 <div class="flex-1 min-w-0">

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onBeforeUnmount, computed, ref, watch } from "vue"
+import { useRoute } from "vue-router"
 import { useJobsStore } from "@/stores/jobs"
 import { useDevicesStore } from "@/stores/devices"
 import { backupApi } from "@/api/backups"
@@ -8,6 +9,7 @@ import LoadingSpinner from "@/components/LoadingSpinner.vue"
 
 const jobsStore = useJobsStore()
 const devicesStore = useDevicesStore()
+const route = useRoute()
 const showFilters = ref<boolean>(false)
 const showFlushDialog = ref<boolean>(false)
 const flushConfirmation = ref<string>("")
@@ -24,8 +26,22 @@ let jobIdSearchTimer: ReturnType<typeof setTimeout> | null = null
 let deviceSearchTimer: ReturnType<typeof setTimeout> | null = null
 
 onMounted(async () => {
+  const routeJobId = typeof route.query.job_id === "string" ? route.query.job_id : ""
+  const routeDevice = typeof route.query.device === "string" ? route.query.device : ""
+
+  if (routeDevice) {
+    filterDevice.value = routeDevice
+  }
+  if (routeJobId) {
+    filterJobId.value = routeJobId
+  }
+
   // Load jobs from database
-  await loadJobsPage()
+  await loadJobsPage(routeJobId || undefined, routeDevice || undefined)
+
+  if (routeJobId) {
+    await jobsStore.loadJobDetails(routeJobId)
+  }
 
   // Load devices for IP lookup
   if (devicesStore.devices.length === 0) {


### PR DESCRIPTION
- Added dedicated error classes for config fetch errors instead of using RuntimeError
- Fixed config size too small errors by making `_read_trailing_output` time‑bounded instead of strictly chunk‑bounded
  - In addition to that, added a additional  safety net config fetch retry if config was to small on the first run
- Added ACOS A10 secret redection patterns
- Added vendor Cisco IOS-XR
- Added vendor Eltex
- The click on any successful backup on the device detail page will now open the corresponding job log
- Added download latest config button next to trigger backup and favorite button on device detail page
- Added limit and offset to `GET /backups/history` endpoint
  - The frontend will now use the new pagination for faster loading times
- Added backend API endpoint to fetch backup counts for the last N days (`GET /backups/history/graph/<device>`)
  - The backup contribution graph is now using this endpoint for faster loading times