### PR TITLE
fix: remove regex pattern to treat a single caret (^) as error/faulty…

### DIFF
--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -36,7 +36,6 @@ class QueuedBackupItem:
 CLI_ERROR_PATTERNS = [
     re.compile(r"^%\s*(?:Unrecognized command|Invalid input detected|Unknown command|Incomplete command)", re.IGNORECASE),
     re.compile(r"Invalid input detected at '\^' marker", re.IGNORECASE),
-    re.compile(r"^\s*\^\s*$"),
     re.compile(r"^\s*syntax error\b", re.IGNORECASE),
 ]
 


### PR DESCRIPTION
remove regex pattern to treat a single caret (^) as error/faulty config

Fixes #39