### PR TITLE
feat: Improve Standalone Docker Compose Setup with PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,18 @@ To run KiwiSSH on your local machine without Docker, follow these steps:
 
 ## Docker
 
-KiwiSSH uses separate Docker images for backend and frontend.
+KiwiSSH uses separate Docker images for backend and frontend. The example Compose stack also includes PostgreSQL for the application database.
 
 - Backend: FastAPI API service
 - Frontend: Nginx serving the built Vue app and proxying `/api/*` to backend
+- PostgreSQL: application data storage
 
-1. Update the [`docker-compose.yaml.example`](docker-compose.yaml.example) with the correct image tags for backend and frontend and set your desired environment variables (optional) and volume mounts. You can find an overview of all available environment variables [here in the README](#environment-variables) or [in the example .env file](backend/.env.example).
-2. Run the [`docker-compose.yaml.example`](docker-compose.yaml.example) file
-3. Open the UI at `http://<IP>:8123`
+1. Update the [`docker-compose.yaml.example`](docker-compose.yaml.example) with the correct host paths, network, database credentials, and any desired environment variables or volume mounts. Use the same PostgreSQL connection values in your `kiwissh.yaml`.
+2. Run the [`docker-compose.yaml.example`](docker-compose.yaml.example) file.
+3. Open the UI at `http://<IP>:8123`.
+
+> [!IMPORTANT]
+> Persist the PostgreSQL data and KiwiSSH backup directories on the host. Data stored only inside a container is lost when that container is recreated.
 
 > [!IMPORTANT]
 > If you're using SSH key authentication (remote git push, device backup auth, or jumphost auth), mount your SSH material into `/home/kiwissh/.ssh` and ensure permissions are correct (typically `600` for private keys/config/known_hosts, owned by `kiwissh` uid:gid 1000:1000).

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ To run KiwiSSH on your local machine without Docker, follow these steps:
 
 ## Docker
 
-KiwiSSH uses separate Docker images for backend and frontend. The example Compose stack also includes PostgreSQL for the application database.
+KiwiSSH uses separate Docker images for backend and frontend. The [example compose stack](docker-compose.yaml.example) also includes PostgreSQL for the application database. If you already have a PostgreSQL database up and running, you may remove the service from the compose file.
 
 - Backend: FastAPI API service
 - Frontend: Nginx serving the built Vue app and proxying `/api/*` to backend
-- PostgreSQL: application data storage
+- PostgreSQL: Application data storage
 
 1. Update the [`docker-compose.yaml.example`](docker-compose.yaml.example) with the correct host paths, network, database credentials, and any desired environment variables or volume mounts. Use the same PostgreSQL connection values in your `kiwissh.yaml`.
 2. Run the [`docker-compose.yaml.example`](docker-compose.yaml.example) file.

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -3,9 +3,30 @@ networks:
     external: true
 
 services:
+  postgres:
+    container_name: kiwissh_postgres
+    image: postgres:latest
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Berlin
+      - POSTGRES_DB=kiwissh
+      - POSTGRES_USER=kiwissh_user
+      - POSTGRES_PASSWORD=change-me
+    volumes:
+      ### Required: Mount PostgreSQL data to persistent storage
+      - /PATH_TO_POSTGRES_DATA:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    hostname: postgres
+    networks:
+      - your-network
+
   backend:
     container_name: kiwissh_backend
-    image: ghcr.io/casudo/kiwissh-backend:<tag>
+    image: ghcr.io/casudo/kiwissh-backend:latest
     restart: unless-stopped
     ### Uncomment ports if you want to access the API docs via http://<IP>:8000/docs
     # ports:
@@ -25,14 +46,19 @@ services:
       # - /PATH_TO_CONFIG/ssh_material:/home/kiwissh/.ssh
     environment:
       - TZ=Europe/Berlin
+    depends_on:
+      postgres:
+        condition: service_healthy
     hostname: kiwissh_backend
     networks:
       - your-network
 
   frontend:
     container_name: kiwissh_frontend
-    image: ghcr.io/casudo/kiwissh-frontend:<tag>
+    image: ghcr.io/casudo/kiwissh-frontend:latest
     restart: unless-stopped
+    environment:
+      - TZ=Europe/Berlin
     ports:
       - 8123:8080
     # labels:


### PR DESCRIPTION
Hello,

I’ve taken the time to test the project and here are a few changes that I think would make it easier for new users to get started.

The stack and architecture used are great; 

I think they could become a solid alternative to Oxidised

## Summary

This PR improves the standalone Docker Compose setup by adding a PostgreSQL service and updating the related documentation.

## Changes

- Add PostgreSQL to the example Compose stack.
- Add a PostgreSQL health check.
- Make the backend wait for PostgreSQL to become healthy.
- Persist PostgreSQL data through a host-mounted volume.
- Use the `latest` tag for the backend and frontend images.
- Update the README with the new setup and persistence requirements.
