### PR TITLE
58 feature allow other types of db for application database

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ It was created as better alternative to RANCID and Oxidized, with a focus on sim
   - [kiwissh.yaml](#kiwisshyaml)
     - [app](#app)
     - [application\_database](#application_database)
+      - [PostgreSQL](#postgresql)
+      - [SQLite](#sqlite)
     - [notifications](#notifications)
     - [sources](#sources)
       - [CSV File](#csv-file)
-      - [PostgreSQL](#postgresql)
+      - [PostgreSQL](#postgresql-1)
       - [HTTP](#http)
       - [Ansible Inventory](#ansible-inventory)
     - [git](#git)
@@ -119,18 +121,18 @@ To run KiwiSSH on your local machine without Docker, follow these steps:
 
 ## Docker
 
-KiwiSSH uses separate Docker images for backend and frontend. The [example compose stack](docker-compose.yaml.example) also includes PostgreSQL for the application database. If you already have a PostgreSQL database up and running, you may remove the service from the compose file.
+KiwiSSH uses separate Docker images for backend and frontend. The [example compose stack](docker-compose.yaml.example) also includes PostgreSQL for the application database. If you already have a PostgreSQL database up and running, or if you prefer the file-based [SQLite](#sqlite) backend, you may remove the PostgreSQL service from the compose file.
 
 - Backend: FastAPI API service
 - Frontend: Nginx serving the built Vue app and proxying `/api/*` to backend
-- PostgreSQL: Application data storage
+- PostgreSQL: Application data storage (optional if using SQLite)
 
 1. Update the [`docker-compose.yaml.example`](docker-compose.yaml.example) with the correct host paths, network, database credentials, and any desired environment variables or volume mounts. Use the same PostgreSQL connection values in your `kiwissh.yaml`.
 2. Run the [`docker-compose.yaml.example`](docker-compose.yaml.example) file.
 3. Open the UI at `http://<IP>:8123`.
 
 > [!IMPORTANT]
-> Persist the PostgreSQL data and KiwiSSH backup directories on the host. Data stored only inside a container is lost when that container is recreated.
+> Persist the application database (PostgreSQL data directory, or the SQLite file) and KiwiSSH backup directories on the host. Data stored only inside a container is lost when that container is recreated.
 
 > [!IMPORTANT]
 > If you're using SSH key authentication (remote git push, device backup auth, or jumphost auth), mount your SSH material into `/home/kiwissh/.ssh` and ensure permissions are correct (typically `600` for private keys/config/known_hosts, owned by `kiwissh` uid:gid 1000:1000).
@@ -193,18 +195,37 @@ Full available options:
 
 ### application_database
 
-The `application_database` segment is used to configure the connection to the PostgreSQL database where KiwiSSH will store its application data (e.g. backup job logs, favorite devices, etc.). This database is required for KiwiSSH to function properly.
+The `application_database` segment configures where KiwiSSH stores its application data (e.g. backup job logs, favorite devices, etc.). This storage is required for KiwiSSH to function properly. Two backends are supported, selected via `application_database.type`:
+
+- `postgresql` (default): connects to an external PostgreSQL server.
+- `sqlite`: a self-contained, file-based database that requires no external server.
+
+> [!NOTE]
+> The frontend always reads log lines through the backend API, so it works identically regardless of the chosen backend.
+> It's still recommended to use PostgreSQL for production deployments, as it is more robust and scalable than SQLite.
+
+#### PostgreSQL
 
 > [!IMPORTANT]
 > Make sure that the database exists and that the provided user has the necessary permissions to create tables and perform operations on the database. KiwiSSH will automatically create the required tables on startup.
 
 | Key | Description | Required | Default Value |
 | --- | ----------- | -------- | ------------- |
+| `application_database.type` | Set to `postgresql`. | No | `postgresql` |
 | `application_database.host` | The host of the PostgreSQL database. | **Yes** | - |
 | `application_database.port` | The port of the PostgreSQL database. | No | `5432` |
 | `application_database.database` | The name of the PostgreSQL database. | **Yes** | - |
 | `application_database.username` | The username for the PostgreSQL database. | **Yes** | - |
 | `application_database.password` | The password for the PostgreSQL database. | **Yes** | - |
+
+#### SQLite
+
+The SQLite database is a single file. The file and its parent directory are created automatically on startup if they do not exist. Relative paths are resolved against the configuration directory. When running in Docker, mount the file to persistent storage so data survives container recreation.
+
+| Key | Description | Required | Default Value |
+| --- | ----------- | -------- | ------------- |
+| `application_database.type` | Set to `sqlite`. | **Yes** | `postgresql` |
+| `application_database.path` | Path to the SQLite database file (e.g. `kiwissh.db` or `/config/kiwissh.db`). | **Yes** | - |
 
 ### notifications
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -892,13 +892,18 @@ class Settings(BaseSettings):
             )
 
     def _build_database_url(self) -> str:
-        """Build application database URL from PostgreSQL configuration.
+        """Build application database URL from the configured backend.
 
         Returns:
             SQLAlchemy database URL string
         """
         if self.application_database is None:
             raise ValueError("Missing required 'application_database' section in kiwissh.yaml")
+
+        if self.application_database.type == "sqlite":
+            ### Resolve relative SQLite paths against the configuration directory
+            resolved = self._resolve_config_relative_path(self.application_database.path)
+            return f"sqlite:///{Path(resolved).as_posix()}"
 
         return self._build_postgres_url(
             host=self.application_database.host,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -721,6 +721,27 @@ class ApplicationDatabaseConfig(BaseModel):
             raise ValueError("application_database.type must be 'postgresql' or 'sqlite'")
         return text
 
+    @model_validator(mode="after")
+    def validate_required_fields(self) -> "ApplicationDatabaseConfig":
+        """Ensure the fields required for the selected backend are provided."""
+        if self.type == "postgresql":
+            missing = [
+                name
+                for name in ("host", "database", "username", "password")
+                if not (getattr(self, name) or "").strip()
+            ]
+            if missing:
+                raise ValueError(
+                    "application_database PostgreSQL connection fields must be non-empty: "
+                    + ", ".join(missing)
+                )
+        elif self.type == "sqlite":
+            if not (self.path or "").strip():
+                raise ValueError(
+                    "application_database.path must be a non-empty file path when type is 'sqlite'"
+                )
+        return self
+
 
 class Settings(BaseSettings):
     """Application settings loaded from environment and config files."""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -693,21 +693,32 @@ class GitConfig(BaseModel):
 
 
 class ApplicationDatabaseConfig(BaseModel):
-    """Application PostgreSQL database configuration."""
+    """Application database configuration.
 
-    host: str
-    port: int = Field(default=5432,ge=1, le=65535)
-    database: str
-    username: str
-    password: str
+    Supports backends selected via `type`:
+      - `postgresql` (default): requires host/database/username/password.
+      - `sqlite`: file-based, requires only `path`.
+    """
 
-    @field_validator("host", "database", "username", "password", mode="before")
+    type: str = "postgresql"
+
+    ### PostgreSQL connection fields (required when type == "postgresql")
+    host: str | None = None
+    port: int = Field(default=5432, ge=1, le=65535)
+    database: str | None = None
+    username: str | None = None
+    password: str | None = None
+
+    ### SQLite connection field (required when type == "sqlite")
+    path: str | None = None
+
+    @field_validator("type", mode="before")
     @classmethod
-    def validate_non_empty_text(cls, value: str | None) -> str:
-        """Require non-empty strings for application database connection fields."""
-        text = "" if value is None else str(value).strip()
-        if not text:
-            raise ValueError("application_database connection fields must be non-empty strings")
+    def normalize_type(cls, value: str | None) -> str:
+        """Normalize and validate the database backend type."""
+        text = ("postgresql" if value is None else str(value)).strip().lower()
+        if text not in {"postgresql", "sqlite"}:
+            raise ValueError("application_database.type must be 'postgresql' or 'sqlite'")
         return text
 
 

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -17,19 +17,40 @@ SessionLocal = None
 
 
 def init_database(settings: Settings) -> None:
-    """Initialize PostgreSQL connection and create application tables."""
+    """Initialize the application database connection and create application tables.
+
+    Supports both PostgreSQL and SQLite backends, selected via
+    `application_database.type` in the configuration.
+    """
     global engine, SessionLocal
 
     app_db = settings.application_database
+
+    if app_db.type == "sqlite":
+        ...
+    elif app_db.type == "postgresql":
+        engine = _create_postgres_engine(settings, app_db)
+    else:
+        raise ValueError(f"Unsupported database type: {app_db.type}")
+
+    ### Create tables
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    logger.info("Application database initialized successfully")
+
+
+def _create_postgres_engine(settings: Settings, app_db) -> "object":
+    """Create a SQLAlchemy engine for a PostgreSQL backend."""
     logger.info(
-        "Connecting to application database '%s' on %s:%s as user '%s'",
+        "Connecting to PostgreSQL application database '%s' on %s:%s as user '%s'",
         app_db.database,
         app_db.host,
         app_db.port,
         app_db.username,
     )
 
-    engine = create_engine(
+    return create_engine(
         settings.database_url,
         echo=False,
         future=True,

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -1,8 +1,9 @@
 """Database connection and initialization."""
 
 import logging
+from pathlib import Path
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker, Session
 from app.db.models import Base
 from typing import Generator
@@ -27,7 +28,7 @@ def init_database(settings: Settings) -> None:
     app_db = settings.application_database
 
     if app_db.type == "sqlite":
-        ...
+        engine = _create_sqlite_engine(settings.database_url, app_db.path)
     elif app_db.type == "postgresql":
         engine = _create_postgres_engine(settings, app_db)
     else:
@@ -62,11 +63,42 @@ def _create_postgres_engine(settings: Settings, app_db) -> "object":
         connect_args={"connect_timeout": 5},
     )
 
-    ### Create tables
-    Base.metadata.create_all(bind=engine)
-    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-    logger.info("Application database initialized successfully")
+def _create_sqlite_engine(database_url: str, db_path: str) -> "object":
+    """Create a SQLAlchemy engine for a SQLite backend.
+
+    Ensures the parent directory exists and enables pragmas (WAL journaling and
+    a busy timeout) so the multi-threaded backend can share the database file.
+    """
+    ### Ensure the parent directory exists so SQLite can create the file
+    parent = Path(db_path).expanduser().parent
+    if parent and not parent.exists():
+        parent.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Connecting to SQLite application database at '%s'", db_path)
+
+    sqlite_engine = create_engine(
+        database_url,
+        echo=False,
+        future=True,
+        pool_pre_ping=True,
+        ### SQLAlchemy uses a single connection per thread guard by default
+        ## the backend runs multiple worker threads, so allow cross-thread usage
+        connect_args={"check_same_thread": False},
+    )
+
+    @event.listens_for(sqlite_engine, "connect")
+    def _set_sqlite_pragmas(dbapi_connection, _connection_record):
+        """Enable WAL mode and a busy timeout for better concurrent access."""
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA busy_timeout=5000")
+            cursor.execute("PRAGMA foreign_keys=ON")
+        finally:
+            cursor.close()
+
+    return sqlite_engine
 
 
 def get_db() -> Generator[Session, None, None]:

--- a/backend/config/kiwissh.yaml.example
+++ b/backend/config/kiwissh.yaml.example
@@ -15,15 +15,25 @@ app:
   api:
     host: "0.0.0.0" # Should be set to 0.0.0.0 when running in Docker to be accessible from outside the container
 
-### Application database (PostgreSQL only)
+### Application database (PostgreSQL or SQLite)
 ## This database stores KiwiSSH-owned data (backup job logs, favorites, etc.)
+##
+## Option A) PostgreSQL (default):
 ## The database itself and the user must already exist, the required tables will be created automatically.
 application_database:
+  type: "postgresql"
   host: "192.168.15.25"
   port: 5432
   database: "kiwissh"
   username: "kiwissh_user"
   password: "kiwissh-user-password"
+
+## Option B) SQLite (file-based, no external database server required):
+## The file (and its parent directory) is created automatically if it does not exist
+## Relative paths are resolved against the configuration directory
+# application_database:
+#   type: "sqlite"
+#   path: "kiwissh.db"
 
 ### Notification settings (optional, disabled by default)
 ## Read about the configuration options in the README.md


### PR DESCRIPTION
## Description

Adds the ability to choose between PostgreSQL and SQLite for the `application_database`.

## How Has This Been Tested?

Not yet.

## Checklist

- [x] I have carefully read [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
